### PR TITLE
No hover needed on poster if img not set

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -37,7 +37,7 @@ type User struct {
 	Password string `gorm:"not null" json:"password" binding:"required"`
 	// The type of user/which auth service they originate from.
 	// Empty if from Watcharr, or the name of the service (eg. jellyfin)
-	Type UserType `gorm:"uniqueIndex:usr_name_to_type;not null" json:"type"`
+	Type UserType `gorm:"uniqueIndex:usr_name_to_type;not null;default:0" json:"type"`
 	// ID of user from the third party service, this will be used purely for lookup of user at signin.
 	ThirdPartyID string `json:"-"`
 	Watched      []Watched

--- a/src/lib/Poster.svelte
+++ b/src/lib/Poster.svelte
@@ -88,6 +88,12 @@
     // aspect-ratio: 2/3;
     transition: all 150ms ease-in;
 
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
     .inner {
       position: absolute;
       visibility: hidden;
@@ -167,9 +173,6 @@
     &:hover,
     &:global(.details-shown) {
       img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
         filter: blur(4px) grayscale(80%);
         // This makes the background very dark,
         // but atleast the text is visible.. may want to change later.

--- a/src/lib/Poster.svelte
+++ b/src/lib/Poster.svelte
@@ -91,7 +91,6 @@
     img {
       width: 100%;
       height: 100%;
-      object-fit: cover;
     }
 
     .inner {

--- a/src/lib/Poster.svelte
+++ b/src/lib/Poster.svelte
@@ -23,33 +23,51 @@
 </script>
 
 <li>
-  <div class="container">
-    <img loading="lazy" src={poster} alt="poster" />
+  <div class={`container${!poster ? " details-shown" : ""}`}>
+    {#if poster}
+      <img loading="lazy" src={poster} alt="poster" />
+    {/if}
     <div class="inner">
       <h2>{title}</h2>
       <span>{desc}</span>
 
       <div id="rating-container" class="rating" bind:this={ratingContainer}>
-        <button class="plain{rating === 5 ? ' lit' : ''}" on:click={() => handleStarClick(5)}>*</button>
-        <button class="plain{rating === 4 ? ' lit' : ''}" on:click={() => handleStarClick(4)}>*</button>
-        <button class="plain{rating === 3 ? ' lit' : ''}" on:click={() => handleStarClick(3)}>*</button>
-        <button class="plain{rating === 2 ? ' lit' : ''}" on:click={() => handleStarClick(2)}>*</button>
-        <button class="plain{rating === 1 ? ' lit' : ''}" on:click={() => handleStarClick(1)}>*</button>
+        <button class="plain{rating === 5 ? ' lit' : ''}" on:click={() => handleStarClick(5)}
+          >*</button
+        >
+        <button class="plain{rating === 4 ? ' lit' : ''}" on:click={() => handleStarClick(4)}
+          >*</button
+        >
+        <button class="plain{rating === 3 ? ' lit' : ''}" on:click={() => handleStarClick(3)}
+          >*</button
+        >
+        <button class="plain{rating === 2 ? ' lit' : ''}" on:click={() => handleStarClick(2)}
+          >*</button
+        >
+        <button class="plain{rating === 1 ? ' lit' : ''}" on:click={() => handleStarClick(1)}
+          >*</button
+        >
       </div>
 
       <div class="btn-container">
         <button
           class={status && status !== "PLANNED" ? "not-active" : ""}
-          on:click={() => wBtnClicked("PLANNED")}><Icon i="calendar" /></button
+          on:click={() => wBtnClicked("PLANNED")}
         >
+          <Icon i="calendar" />
+        </button>
         <button
           class={status && status !== "WATCHING" ? "not-active" : ""}
-          on:click={() => wBtnClicked("WATCHING")}><Icon i="clock" /></button
+          on:click={() => wBtnClicked("WATCHING")}
         >
+          <Icon i="clock" />
+        </button>
         <button
           class={status && status !== "FINISHED" ? "not-active" : ""}
-          on:click={() => wBtnClicked("FINISHED")}><Icon i="check" /></button
+          on:click={() => wBtnClicked("FINISHED")}
         >
+          <Icon i="check" />
+        </button>
       </div>
     </div>
   </div>
@@ -65,6 +83,7 @@
     border-radius: 5px;
     width: 170px;
     height: 100%;
+    min-height: 256.367px;
     position: relative;
     // aspect-ratio: 2/3;
     transition: all 150ms ease-in;
@@ -142,11 +161,11 @@
 
     &:hover {
       transform: scale(1.3);
+      z-index: 99;
     }
 
-    &:hover {
-      z-index: 99;
-
+    &:hover,
+    &:global(.details-shown) {
       img {
         width: 100%;
         height: 100%;

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -15,7 +15,9 @@
   {#if watched?.length > 0}
     {#each watched as w (w.id)}
       <Poster
-        poster={"http://localhost:3080/img" + w.content.poster_path}
+        poster={w.content.poster_path
+          ? "http://localhost:3080/img" + w.content.poster_path
+          : undefined}
         title={w.content.title}
         desc={w.content.overview}
         rating={w.rating}

--- a/src/routes/(app)/search/[query]/+page.svelte
+++ b/src/routes/(app)/search/[query]/+page.svelte
@@ -70,7 +70,7 @@
   {#if data?.results?.length > 0}
     {#each data.results as w (w.id)}
       <Poster
-        poster={"https://image.tmdb.org/t/p/w500" + w.poster_path}
+        poster={w.poster_path ? "https://image.tmdb.org/t/p/w500" + w.poster_path : undefined}
         title={w.title ?? w.name}
         desc={w.overview}
         onBtnClicked={(t, r) => addWatched(w.id, w.title ? "movie" : "tv", t, r)}


### PR DESCRIPTION
Show content details without requiring hover, if the poster is not set.

Also made poster images take up 100% width and height all the time, instead of only on hover.

Closes #2 