### PR TITLE
Only show available auth providers

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -159,6 +159,7 @@ func (b *BaseRouter) addAuthRoutes() {
 		c.Status(400)
 	})
 
+	// Jellyfin login
 	auth.POST("/jellyfin", func(c *gin.Context) {
 		var user User
 		if c.ShouldBindJSON(&user) == nil {
@@ -186,5 +187,10 @@ func (b *BaseRouter) addAuthRoutes() {
 			return
 		}
 		c.Status(400)
+	})
+
+	// Get available auth providers
+	auth.GET("/available", func(c *gin.Context) {
+		c.JSON(http.StatusOK, AvailableAuthProviders)
 	})
 }

--- a/server/watcharr.go
+++ b/server/watcharr.go
@@ -20,6 +20,8 @@ type GormModel struct {
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"deletedAt"`
 }
 
+var AvailableAuthProviders = []string{}
+
 func main() {
 	fmt.Println("Watcharr Starting")
 
@@ -67,6 +69,10 @@ func main() {
 func ensureEnv() {
 	if os.Getenv("JWT_SECRET") == "" {
 		log.Fatal("JWT_SECRET env var missing!")
+	}
+
+	if os.Getenv("JELLYFIN_HOST") != "" {
+		AvailableAuthProviders = append(AvailableAuthProviders, "jellyfin")
 	}
 }
 

--- a/src/routes/(plain)/login/+page.svelte
+++ b/src/routes/(plain)/login/+page.svelte
@@ -2,6 +2,7 @@
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import Icon from "@/lib/Icon.svelte";
+  import type { Icon as Icons } from "@/types";
   import { noAuthAxios } from "@/lib/api";
   import { onMount, afterUpdate } from "svelte";
 
@@ -55,6 +56,10 @@
         }
       });
   }
+
+  async function getLoginProviders() {
+    return (await noAuthAxios.get("/auth/available")).data as Icons[];
+  }
 </script>
 
 <div>
@@ -82,7 +87,11 @@
         <span class="login-with" style="font-weight: bold">Login With</span>
         <div class="login-btns">
           <button type="submit"><span class="watcharr">W</span>Watcharr</button>
-          <button type="submit" name="jellyfin"><Icon i="jellyfin" wh={18} />Jellyfin</button>
+          {#await getLoginProviders() then providers}
+            {#each providers as p}
+              <button type="submit" name="jellyfin" class="other"><Icon i={p} wh={18} />{p}</button>
+            {/each}
+          {/await}
         </div>
       {:else}
         <div class="login-btns">
@@ -150,6 +159,20 @@
         font-family: "Rampart One";
         font-size: 18px;
         line-height: 18px;
+      }
+
+      &.other {
+        overflow: hidden;
+        animation: 250ms ease otherbtn;
+
+        @keyframes otherbtn {
+          from {
+            width: 0px;
+          }
+          to {
+            width: 100%;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Only show available auth providers on login page, so at the moment with there only being Watcharr and Jellyfin auth support, the jellyfin button will be hidden when disabled.

Closes #22 