### PR TITLE
PersonPoster: Fix white flash on hover

### DIFF
--- a/src/lib/PersonPoster.svelte
+++ b/src/lib/PersonPoster.svelte
@@ -65,7 +65,9 @@
     height: 100%;
     min-height: 256.367px;
     position: relative;
-    transition: transform 150ms ease, outline 50ms ease;
+    transition:
+      transform 150ms ease,
+      outline 50ms ease;
     cursor: pointer;
 
     img {
@@ -112,7 +114,11 @@
 
       h2,
       h3 {
-        font-family: sans-serif, system-ui, -apple-system, BlinkMacSystemFont;
+        font-family:
+          sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont;
         font-size: 18px;
         color: white;
         word-wrap: break-word;
@@ -144,7 +150,7 @@
     &:not(:not(.no-zoom)) {
       &:hover,
       &:focus-within {
-        outline: 3px solid black;
+        outline: 3px solid $text-color;
       }
     }
 


### PR DESCRIPTION
Fixing the theming has seemed to have fixed the white outline flashing on hover issue.

![image](https://github.com/sbondCo/Watcharr/assets/37304121/e54c59a2-16a7-4b56-8122-0fc74d138819)

Closes #112 