### PR TITLE
Socialize - Allow viewing other watchlists

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -44,6 +44,13 @@ type User struct {
 	// Auth token from third party (jellyfin)
 	ThirdPartyAuth string `json:"-"`
 	Watched        []Watched
+	// All user settings cols, in another struct for reusability
+	UserSettings
+}
+
+type UserSettings struct {
+	// Is profile private
+	Private bool `gorm:"default:false" json:"private"`
 }
 
 type JellyfinAuth struct {

--- a/server/routes.go
+++ b/server/routes.go
@@ -391,3 +391,46 @@ func (b *BaseRouter) addJellyfinRoutes() {
 		c.JSON(http.StatusOK, response)
 	})
 }
+
+func (b *BaseRouter) addUserRoutes() {
+	u := b.rg.Group("/user").Use(AuthRequired(b.db))
+
+	// Update current user settings
+	u.POST("/update", func(c *gin.Context) {
+		userId := c.MustGet("userId").(uint)
+		var ur UserSettings
+		err := c.ShouldBindJSON(&ur)
+		if err == nil {
+			response, err := userUpdate(b.db, userId, ur)
+			if err != nil {
+				c.JSON(http.StatusForbidden, ErrorResponse{Error: err.Error()})
+				return
+			}
+			c.JSON(http.StatusOK, response)
+			return
+		}
+		c.AbortWithStatusJSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+	})
+
+	// Get current user setting
+	u.GET("/settings", func(c *gin.Context) {
+		userId := c.MustGet("userId").(uint)
+		response, err := userGetSettings(b.db, userId)
+		if err != nil {
+			c.JSON(http.StatusForbidden, ErrorResponse{Error: err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	})
+
+	// // Search users
+	//	u.GET("/:query", func(c *gin.Context) {
+	//		uq := c.MustGet("query").(string)
+	//		response, err := userSearch(b.db, uq)
+	//		if err != nil {
+	//			c.JSON(http.StatusForbidden, ErrorResponse{Error: err.Error()})
+	//			return
+	//		}
+	//		c.JSON(http.StatusOK, response)
+	//	})
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -441,7 +441,8 @@ func (b *BaseRouter) addUserRoutes() {
 
 	// Search users
 	u.GET("/search/:query", func(c *gin.Context) {
-		response, err := userSearch(b.db, c.Param("query"))
+		userId := c.MustGet("userId").(uint)
+		response, err := userSearch(b.db, userId, c.Param("query"))
 		if err != nil {
 			c.JSON(http.StatusForbidden, ErrorResponse{Error: err.Error()})
 			return

--- a/server/routes.go
+++ b/server/routes.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -203,6 +204,21 @@ func (b *BaseRouter) addWatchedRoutes() {
 	watched.GET("", func(c *gin.Context) {
 		userId := c.MustGet("userId").(uint)
 		c.JSON(http.StatusOK, getWatched(b.db, userId))
+	})
+
+	watched.GET(":id/:username", func(c *gin.Context) {
+		id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+		if err != nil {
+			slog.Error("getPublicWatched route failed to convert id param to uint", "id", id)
+			c.Status(400)
+			return
+		}
+		response, err := getPublicWatched(b.db, uint(id), c.Param("username"))
+		if err != nil {
+			c.JSON(http.StatusForbidden, ErrorResponse{Error: err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, response)
 	})
 
 	watched.POST("", func(c *gin.Context) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -423,14 +423,13 @@ func (b *BaseRouter) addUserRoutes() {
 		c.JSON(http.StatusOK, response)
 	})
 
-	// // Search users
-	//	u.GET("/:query", func(c *gin.Context) {
-	//		uq := c.MustGet("query").(string)
-	//		response, err := userSearch(b.db, uq)
-	//		if err != nil {
-	//			c.JSON(http.StatusForbidden, ErrorResponse{Error: err.Error()})
-	//			return
-	//		}
-	//		c.JSON(http.StatusOK, response)
-	//	})
+	// Search users
+	u.GET("/search/:query", func(c *gin.Context) {
+		response, err := userSearch(b.db, c.Param("query"))
+		if err != nil {
+			c.JSON(http.StatusForbidden, ErrorResponse{Error: err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	})
 }

--- a/server/user.go
+++ b/server/user.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+
+	"gorm.io/gorm"
+)
+
+// This really only works if all settings are repassed in, otherwise they
+// will be reset to their default value.
+// When more settings are added in, this should be updated to work so you
+// only have to pass in the setting you want to update.
+func userUpdate(db *gorm.DB, userId uint, ur UserSettings) (UserSettings, error) {
+	slog.Debug("user update request running", "user_id", userId, "ur", ur)
+	user := new(User)
+	res := db.Where("id = ?", userId).Take(&user)
+	if res.Error != nil {
+		slog.Error("user update failed", "user_id", userId, "error", "failed to retrieve user from database")
+		return UserSettings{}, errors.New("failed to retrieve user")
+	}
+	user.Private = ur.Private
+	db.Save(&user)
+	return UserSettings{Private: user.Private}, nil
+}
+
+func userGetSettings(db *gorm.DB, userId uint) (UserSettings, error) {
+	slog.Debug("user update request running", "user_id", userId)
+	user := new(User)
+	res := db.Where("id = ?", userId).Take(&user)
+	if res.Error != nil {
+		slog.Error("user get failed", "user_id", userId, "error", "failed to retrieve user from database")
+		return UserSettings{}, errors.New("failed to retrieve user")
+	}
+	return UserSettings{Private: user.Private}, nil
+}

--- a/server/user.go
+++ b/server/user.go
@@ -41,10 +41,10 @@ func userGetSettings(db *gorm.DB, userId uint) (UserSettings, error) {
 	return UserSettings{Private: user.Private}, nil
 }
 
-func userSearch(db *gorm.DB, q string) ([]PublicUser, error) {
+func userSearch(db *gorm.DB, currentUsersId uint, q string) ([]PublicUser, error) {
 	slog.Debug("user search request running", "query", q)
 	users := new([]PublicUser)
-	res := db.Where("private = 0 AND username LIKE ?", "%"+q+"%").Table("users").Find(&users)
+	res := db.Where("private = 0 AND username LIKE ? AND id != ?", "%"+q+"%", currentUsersId).Table("users").Find(&users)
 	if res.Error != nil {
 		slog.Error("user search failed", "error", "failed to query database")
 		return []PublicUser{}, errors.New("failed to find users")

--- a/server/user.go
+++ b/server/user.go
@@ -7,6 +7,12 @@ import (
 	"gorm.io/gorm"
 )
 
+// Public user details for search results
+type PublicUser struct {
+	ID       uint   `json:"id"`
+	Username string `json:"username"`
+}
+
 // This really only works if all settings are repassed in, otherwise they
 // will be reset to their default value.
 // When more settings are added in, this should be updated to work so you
@@ -33,4 +39,15 @@ func userGetSettings(db *gorm.DB, userId uint) (UserSettings, error) {
 		return UserSettings{}, errors.New("failed to retrieve user")
 	}
 	return UserSettings{Private: user.Private}, nil
+}
+
+func userSearch(db *gorm.DB, q string) ([]PublicUser, error) {
+	slog.Debug("user search request running", "query", q)
+	users := new([]PublicUser)
+	res := db.Where("private = 0 AND username LIKE ?", "%"+q+"%").Table("users").Find(&users)
+	if res.Error != nil {
+		slog.Error("user search failed", "error", "failed to query database")
+		return []PublicUser{}, errors.New("failed to find users")
+	}
+	return *users, nil
 }

--- a/server/watcharr.go
+++ b/server/watcharr.go
@@ -97,6 +97,7 @@ func main() {
 	br.addActivityRoutes()
 	br.addProfileRoutes()
 	br.addJellyfinRoutes()
+	br.addUserRoutes()
 	br.rg.Static("/img", "./data/img")
 
 	gine.Run("0.0.0.0:3080")

--- a/src/lib/Checkbox.svelte
+++ b/src/lib/Checkbox.svelte
@@ -1,5 +1,16 @@
+<!-- TODO: Allow disabling so when doing request, it cant be clicked again -->
+
+<script lang="ts">
+  export let value: boolean = false;
+  export let toggled: (on: boolean) => void;
+
+  function checkboxChange(e: Event) {
+    toggled((e.target as HTMLInputElement).checked);
+  }
+</script>
+
 <div class="toggle-pill-color">
-  <input type="checkbox" id="checkbox" />
+  <input bind:checked={value} type="checkbox" id="checkbox" on:change={checkboxChange} />
   <label for="checkbox"></label>
 </div>
 

--- a/src/lib/Checkbox.svelte
+++ b/src/lib/Checkbox.svelte
@@ -3,13 +3,35 @@
   export let toggled: (on: boolean) => void;
   export let disabled = false;
 
+  let actualDisabled = false;
+
+  $: {
+    // In cases where we disable and enable the checkbox super fast
+    // it ends up looking like a jittery mess. To circumvent this
+    // issue, we add a small delay before undisabling.
+    // (eg. fast internet and net request dis and re enables it quickly)
+    if (disabled) {
+      actualDisabled = true;
+    } else {
+      setTimeout(() => {
+        actualDisabled = disabled;
+      }, 150);
+    }
+  }
+
   function checkboxChange(e: Event) {
     toggled((e.target as HTMLInputElement).checked);
   }
 </script>
 
 <div class="toggle-pill-color">
-  <input bind:checked={value} {disabled} type="checkbox" id="checkbox" on:change={checkboxChange} />
+  <input
+    bind:checked={value}
+    disabled={actualDisabled}
+    type="checkbox"
+    id="checkbox"
+    on:change={checkboxChange}
+  />
   <label for="checkbox"></label>
 </div>
 

--- a/src/lib/Checkbox.svelte
+++ b/src/lib/Checkbox.svelte
@@ -1,0 +1,47 @@
+<div class="toggle-pill-color">
+  <input type="checkbox" id="checkbox" />
+  <label for="checkbox"></label>
+</div>
+
+<style lang="scss">
+  .toggle-pill-color {
+    width: min-content;
+
+    input {
+      display: none;
+    }
+
+    input:checked + label {
+      background: $success;
+
+      &::before {
+        left: 1.6em;
+      }
+    }
+
+    label {
+      display: block;
+      position: relative;
+      width: 3em;
+      height: 1.6em;
+      border-radius: 1em;
+      background: $error;
+      cursor: pointer;
+      user-select: none;
+      transition: background 0.1s ease-in-out;
+
+      &::before {
+        content: "";
+        display: block;
+        width: 1.2em;
+        height: 1.2em;
+        border-radius: 1em;
+        background: #fff;
+        position: absolute;
+        left: 0.2em;
+        top: 0.2em;
+        transition: all 0.2s ease-in-out;
+      }
+    }
+  }
+</style>

--- a/src/lib/Checkbox.svelte
+++ b/src/lib/Checkbox.svelte
@@ -1,8 +1,7 @@
-<!-- TODO: Allow disabling so when doing request, it cant be clicked again -->
-
 <script lang="ts">
   export let value: boolean = false;
   export let toggled: (on: boolean) => void;
+  export let disabled = false;
 
   function checkboxChange(e: Event) {
     toggled((e.target as HTMLInputElement).checked);
@@ -10,7 +9,7 @@
 </script>
 
 <div class="toggle-pill-color">
-  <input bind:checked={value} type="checkbox" id="checkbox" on:change={checkboxChange} />
+  <input bind:checked={value} {disabled} type="checkbox" id="checkbox" on:change={checkboxChange} />
   <label for="checkbox"></label>
 </div>
 
@@ -20,13 +19,18 @@
 
     input {
       display: none;
-    }
 
-    input:checked + label {
-      background: $success;
+      &:checked + label {
+        background: $success;
 
-      &::before {
-        left: 1.6em;
+        &::before {
+          left: 1.6em;
+        }
+      }
+
+      &:disabled + label {
+        opacity: 0.5;
+        cursor: not-allowed;
       }
     }
 
@@ -39,7 +43,9 @@
       background: $error;
       cursor: pointer;
       user-select: none;
-      transition: background 0.1s ease-in-out;
+      transition:
+        opacity 100ms ease-in-out,
+        opacity 100ms ease-in-out;
 
       &::before {
         content: "";

--- a/src/lib/Poster.svelte
+++ b/src/lib/Poster.svelte
@@ -27,6 +27,7 @@
   export let rating: number | undefined = undefined;
   export let status: WatchedStatus | undefined = undefined;
   export let small = false;
+  export let disableInteraction = false;
 
   // If poster is active (scaled up)
   let posterActive = false;
@@ -89,7 +90,7 @@
   on:mouseleave={() => (posterActive = false)}
   on:click={() => (posterActive = true)}
   on:keypress={() => console.log("on kpress")}
-  class={posterActive ? "active" : ""}
+  class={`${posterActive ? "active " : ""}${disableInteraction ? "interaction-disabled" : ""}`}
 >
   <div class={`container${!poster ? " details-shown" : ""}`} bind:this={containerEl}>
     {#if poster}
@@ -207,6 +208,13 @@
 <style lang="scss">
   li.active {
     cursor: pointer;
+  }
+
+  li.interaction-disabled {
+    button {
+      pointer-events: none;
+      cursor: default;
+    }
   }
 
   .container {

--- a/src/lib/Poster.svelte
+++ b/src/lib/Poster.svelte
@@ -218,7 +218,11 @@
       cursor: default;
       background-color: transparent;
       border: unset;
-      filter: invert(1);
+      fill: white;
+
+      span {
+        color: white !important;
+      }
 
       .unrated-text {
         display: flex;

--- a/src/lib/Poster.svelte
+++ b/src/lib/Poster.svelte
@@ -144,7 +144,9 @@
           }}
         >
           <span>*</span>
-          <span>{rating ? rating : "Rate"}</span>
+          <span class={!rating && disableInteraction ? "unrated-text" : ""}>
+            {rating ? rating : disableInteraction ? "Unrated" : "Rate"}
+          </span>
           {#if ratingsShown}
             <div>
               {#each [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] as v}
@@ -214,6 +216,15 @@
     button {
       pointer-events: none;
       cursor: default;
+      background-color: transparent;
+      border: unset;
+      filter: invert(1);
+
+      .unrated-text {
+        display: flex;
+        align-items: center;
+        font-size: 15px !important;
+      }
     }
   }
 

--- a/src/lib/UsersList.svelte
+++ b/src/lib/UsersList.svelte
@@ -6,7 +6,7 @@
 
 <ul>
   {#each users as user}
-    <li><a href="">{user.username}</a></li>
+    <li><a href="/lists/{user.id}/{user.username}">{user.username}</a></li>
   {/each}
 </ul>
 

--- a/src/lib/UsersList.svelte
+++ b/src/lib/UsersList.svelte
@@ -6,7 +6,7 @@
 
 <ul>
   {#each users as user}
-    <li><a href="/lists/{user.id}/{user.username}">{user.username}</a></li>
+    <li title={user.username}><a href="/lists/{user.id}/{user.username}">{user.username}</a></li>
   {/each}
 </ul>
 
@@ -20,16 +20,20 @@
     justify-content: center;
 
     li {
+      display: flex;
       min-width: 50px;
+      max-width: 200px;
 
       a {
-        display: flex;
-        justify-content: center;
+        flex-shrink: 1;
         width: 100%;
         height: 100%;
         padding: 3px 8px;
         border-radius: 4px;
         background-color: $accent-color;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
         transition:
           background-color 150ms ease,
           color 150ms ease;

--- a/src/lib/UsersList.svelte
+++ b/src/lib/UsersList.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { PublicUser } from "@/types";
+
+  export let users: PublicUser[];
+</script>
+
+<ul>
+  {#each users as user}
+    <li><a href="">{user.username}</a></li>
+  {/each}
+</ul>
+
+<style lang="scss">
+  ul {
+    display: flex;
+    flex-flow: row;
+    gap: 10px;
+    margin: 5px 20px;
+    list-style: none;
+    justify-content: center;
+
+    li {
+      min-width: 50px;
+
+      a {
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        padding: 3px 8px;
+        border-radius: 4px;
+        background-color: $accent-color;
+        transition:
+          background-color 150ms ease,
+          color 150ms ease;
+
+        &:hover {
+          color: $bg-color;
+          background-color: $accent-color-hover;
+        }
+      }
+    }
+  }
+</style>

--- a/src/lib/WatchedList.svelte
+++ b/src/lib/WatchedList.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import Icon from "@/lib/Icon.svelte";
+  import Poster from "@/lib/Poster.svelte";
+  import PosterList from "@/lib/PosterList.svelte";
+  import { activeFilter } from "@/store";
+  import type { Watched } from "@/types";
+
+  export let list: Watched[];
+  export let isPublicList: boolean = false;
+
+  $: filter = $activeFilter;
+  $: watched = list.sort((a, b) => {
+    if (filter[0] === "DATEADDED" && filter[1] === "UP") {
+      return Date.parse(a.createdAt) - Date.parse(b.createdAt);
+    } else if (filter[0] === "ALPHA") {
+      if (filter[1] === "UP") return a.content.title.localeCompare(b.content.title);
+      else if (filter[1] === "DOWN") return b.content.title.localeCompare(a.content.title);
+    } else if (filter[0] === "LASTCHANGED") {
+      if (filter[1] === "UP") return Date.parse(a.updatedAt) - Date.parse(b.updatedAt);
+      else if (filter[1] === "DOWN") return Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+    } else if (filter[0] === "RATING") {
+      if (filter[1] === "UP") return (a.rating ?? 0) - (b.rating ?? 0);
+      else if (filter[1] === "DOWN") return (b.rating ?? 0) - (a.rating ?? 0);
+    }
+    // default DATEADDED DOWN
+    return Date.parse(b.createdAt) - Date.parse(a.createdAt);
+  });
+</script>
+
+<PosterList>
+  {#if watched?.length > 0}
+    {#each watched as w (w.id)}
+      <Poster
+        id={w.id}
+        media={{
+          id: w.content.tmdbId,
+          poster_path: w.content.poster_path,
+          title: w.content.title,
+          overview: w.content.overview,
+          media_type: w.content.type,
+          release_date: w.content.release_date,
+          first_air_date: w.content.first_air_date
+        }}
+        rating={w.rating}
+        status={w.status}
+        disableInteraction={isPublicList}
+      />
+    {/each}
+  {:else}
+    <div class="empty-list">
+      <Icon i="reel" wh={80} />
+      {#if isPublicList}
+        <h2 class="norm">This watched list is empty!</h2>
+        <h4 class="norm">Come back later to see if they have added anything.</h4>
+      {:else}
+        <h2 class="norm">Your watched list is empty!</h2>
+        <h4 class="norm">Try searching for something you would like to add.</h4>
+      {/if}
+    </div>
+  {/if}
+</PosterList>
+
+<style lang="scss">
+  .empty-list {
+    display: flex;
+    flex-flow: column;
+    gap: 5px;
+    align-items: center;
+
+    h2 {
+      margin-top: 10px;
+    }
+
+    h4 {
+      font-weight: normal;
+    }
+  }
+</style>

--- a/src/lib/util/api.ts
+++ b/src/lib/util/api.ts
@@ -136,7 +136,11 @@ export async function contentExistsOnJellyfin(
   }
 }
 
-export function updateUserSetting<K extends keyof UserSettings>(name: K, value: UserSettings[K]) {
+export function updateUserSetting<K extends keyof UserSettings>(
+  name: K,
+  value: UserSettings[K],
+  done?: () => void
+) {
   console.log("Updating user setting", name, "to", value);
   const uSettings = get(userSettings);
   const originalValue = uSettings[name];
@@ -148,6 +152,7 @@ export function updateUserSetting<K extends keyof UserSettings>(name: K, value: 
         uSettings[name] = value;
         userSettings.update((u) => (u = uSettings));
         notify({ id: nid, type: "success", text: "Updated" });
+        if (typeof done !== "undefined") done();
       }
     })
     .catch((err) => {
@@ -155,6 +160,7 @@ export function updateUserSetting<K extends keyof UserSettings>(name: K, value: 
       notify({ id: nid, type: "error", text: "Couldn't Update" });
       uSettings[name] = originalValue;
       userSettings.update((u) => (u = uSettings));
+      if (typeof done !== "undefined") done();
     });
 }
 

--- a/src/lib/util/helpers.ts
+++ b/src/lib/util/helpers.ts
@@ -4,6 +4,7 @@ import type {
   MediaType,
   TMDBContentCreditsCrew,
   Theme,
+  TokenClaims,
   Watched,
   WatchedStatus
 } from "@/types";
@@ -158,5 +159,15 @@ export function toggleTheme(theme: Theme) {
   } else {
     document.documentElement.classList.remove("theme-dark");
     appTheme.update((t) => (t = "light"));
+  }
+}
+
+export function parseTokenPayload(): TokenClaims | undefined {
+  try {
+    const token = localStorage.getItem("token");
+    if (!token) return;
+    return JSON.parse(atob(token.split(".")[1])) as TokenClaims;
+  } catch (err) {
+    return;
   }
 }

--- a/src/norm.scss
+++ b/src/norm.scss
@@ -202,6 +202,11 @@
         border-right: 1px solid rgba($color: black, $alpha: 0.2);
         padding: 10px 12px;
         padding-left: 9px;
+
+        a {
+          color: white;
+          text-decoration: underline;
+        }
       }
 
       button {

--- a/src/norm.scss
+++ b/src/norm.scss
@@ -177,8 +177,8 @@
 
       &.error {
         color: white;
-        background-color: #f3555a;
-        border: 1px solid #f3555a;
+        background-color: $error;
+        border: 1px solid $error;
 
         span {
           border-color: rgba($color: white, $alpha: 0.5);
@@ -187,8 +187,8 @@
 
       &.success {
         color: white;
-        background-color: #28a745;
-        border: 1px solid #28a745;
+        background-color: $success;
+        border: 1px solid $success;
 
         span {
           border-color: rgba($color: white, $alpha: 0.5);

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -5,7 +5,7 @@
   import PageError from "@/lib/PageError.svelte";
   import Spinner from "@/lib/Spinner.svelte";
   import { isTouch } from "@/lib/util/helpers";
-  import { activeFilter, clearAllStores, watchedList } from "@/store";
+  import { activeFilter, clearAllStores, userSettings, watchedList } from "@/store";
   import axios from "axios";
   import { get } from "svelte/store";
 
@@ -69,11 +69,14 @@
     subMenuShown = false;
   }
 
-  async function getWatchedList() {
+  async function getInitialData() {
     if (localStorage.getItem("token")) {
-      const w = await axios.get("/watched");
+      const [w, u] = await Promise.all([axios.get("/watched"), axios.get("/user/settings")]);
       if (w?.data?.length > 0) {
         watchedList.update((wl) => (wl = w.data));
+      }
+      if (u?.data) {
+        userSettings.update((us) => (us = u.data));
       }
     } else {
       goto("/login?again=1");
@@ -166,12 +169,12 @@
   </div>
 </nav>
 
-{#await getWatchedList()}
+{#await getInitialData()}
   <Spinner />
 {:then}
   <slot />
 {:catch err}
-  <PageError pretty="Failed to load watched list!" error={err} />
+  <PageError pretty="Failed to retrieve user data!" error={err} />
 {/await}
 
 <style lang="scss">

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -4,7 +4,8 @@
   import Icon from "@/lib/Icon.svelte";
   import PageError from "@/lib/PageError.svelte";
   import Spinner from "@/lib/Spinner.svelte";
-  import { isTouch } from "@/lib/util/helpers";
+  import { isTouch, parseTokenPayload } from "@/lib/util/helpers";
+  import { notify } from "@/lib/util/notify";
   import { activeFilter, clearAllStores, userSettings, watchedList } from "@/store";
   import axios from "axios";
   import { get } from "svelte/store";
@@ -67,6 +68,31 @@
   function profile() {
     goto("/profile");
     subMenuShown = false;
+  }
+
+  function shareWatchedList() {
+    const nid = notify({ type: "loading", text: "Getting link" });
+    const ud = parseTokenPayload();
+    console.log(ud);
+    if (ud?.userId && ud?.username) {
+      const shareLink = `${window.location.host}/lists/${ud.userId}/${ud.username}`;
+      navigator.clipboard
+        .writeText(shareLink)
+        .then(() => {
+          notify({ id: nid, type: "success", text: "Copied share link" });
+        })
+        .catch((r) => {
+          console.error("Failed to copy list share link", r);
+          notify({
+            id: nid,
+            type: "error",
+            text: `Failed to copy share link:<br/><a href="${shareLink}" target="_blank">${shareLink}</a>`,
+            time: 20000
+          });
+        });
+    } else {
+      notify({ id: nid, type: "error", text: "Failed to get link" });
+    }
   }
 
   async function getInitialData() {
@@ -161,6 +187,7 @@
           <h5 title={username}>Hi {username}!</h5>
         {/if}
         <button class="plain" on:click={() => profile()}>Profile</button>
+        <button class="plain" on:click={() => shareWatchedList()}>Share List</button>
         <button class="plain" on:click={() => logout()}>Logout</button>
         <!-- svelte-ignore missing-declaration -->
         <span>v{__WATCHARR_VERSION__}</span>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -17,6 +17,7 @@
   let filterMenuShown = false;
 
   $: filter = $activeFilter;
+  $: settings = $userSettings;
 
   function handleProfileClick() {
     if (!localStorage.getItem("token")) {
@@ -187,7 +188,9 @@
           <h5 title={username}>Hi {username}!</h5>
         {/if}
         <button class="plain" on:click={() => profile()}>Profile</button>
-        <button class="plain" on:click={() => shareWatchedList()}>Share List</button>
+        {#if !settings.private}
+          <button class="plain" on:click={() => shareWatchedList()}>Share List</button>
+        {/if}
         <button class="plain" on:click={() => logout()}>Logout</button>
         <!-- svelte-ignore missing-declaration -->
         <span>v{__WATCHARR_VERSION__}</span>

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1,72 +1,10 @@
 <script lang="ts">
-  import Icon from "@/lib/Icon.svelte";
-  import Poster from "@/lib/Poster.svelte";
-  import PosterList from "@/lib/PosterList.svelte";
-  import { activeFilter, watchedList } from "@/store";
-
-  $: filter = $activeFilter;
-  $: watched = $watchedList.sort((a, b) => {
-    if (filter[0] === "DATEADDED" && filter[1] === "UP") {
-      return Date.parse(a.createdAt) - Date.parse(b.createdAt);
-    } else if (filter[0] === "ALPHA") {
-      if (filter[1] === "UP") return a.content.title.localeCompare(b.content.title);
-      else if (filter[1] === "DOWN") return b.content.title.localeCompare(a.content.title);
-    } else if (filter[0] === "LASTCHANGED") {
-      if (filter[1] === "UP") return Date.parse(a.updatedAt) - Date.parse(b.updatedAt);
-      else if (filter[1] === "DOWN") return Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
-    } else if (filter[0] === "RATING") {
-      if (filter[1] === "UP") return (a.rating ?? 0) - (b.rating ?? 0);
-      else if (filter[1] === "DOWN") return (b.rating ?? 0) - (a.rating ?? 0);
-    }
-    // default DATEADDED DOWN
-    return Date.parse(b.createdAt) - Date.parse(a.createdAt);
-  });
+  import WatchedList from "@/lib/WatchedList.svelte";
+  import { watchedList } from "@/store";
 </script>
 
 <svelte:head>
   <title>Watched List</title>
 </svelte:head>
 
-<PosterList>
-  {#if watched?.length > 0}
-    {#each watched as w (w.id)}
-      <Poster
-        id={w.id}
-        media={{
-          id: w.content.tmdbId,
-          poster_path: w.content.poster_path,
-          title: w.content.title,
-          overview: w.content.overview,
-          media_type: w.content.type,
-          release_date: w.content.release_date,
-          first_air_date: w.content.first_air_date
-        }}
-        rating={w.rating}
-        status={w.status}
-      />
-    {/each}
-  {:else}
-    <div class="empty-list">
-      <Icon i="reel" wh={80} />
-      <h2 class="norm">Your watched list is empty!</h2>
-      <h4 class="norm">Try searching for something you would like to add.</h4>
-    </div>
-  {/if}
-</PosterList>
-
-<style lang="scss">
-  .empty-list {
-    display: flex;
-    flex-flow: column;
-    gap: 5px;
-    align-items: center;
-
-    h2 {
-      margin-top: 10px;
-    }
-
-    h4 {
-      font-weight: normal;
-    }
-  }
-</style>
+<WatchedList list={$watchedList} />

--- a/src/routes/(app)/lists/[id]/[username]/+page.svelte
+++ b/src/routes/(app)/lists/[id]/[username]/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import PageError from "@/lib/PageError.svelte";
+  import Spinner from "@/lib/Spinner.svelte";
+  import WatchedList from "@/lib/WatchedList.svelte";
+  import { notify } from "@/lib/util/notify.js";
+  import type { Watched } from "@/types.js";
+  import axios from "axios";
+
+  export let data;
+
+  async function getPublicWatchedList(id?: number, username?: string) {
+    if (!id || !username) {
+      console.error("getPublicWatchedList requires and id and username", id, username);
+      notify({ type: "error", text: "Couldn't fetch list" });
+    }
+    return (await axios.get(`/watched/${id}/${username}`)).data as Watched[];
+  }
+</script>
+
+<svelte:head>
+  <title>{data.username}'s Watched List</title>
+</svelte:head>
+
+{#await getPublicWatchedList(Number(data.id), data.username)}
+  <Spinner />
+{:then watched}
+  <WatchedList list={watched} isPublicList={true} />
+{:catch err}
+  <PageError pretty="Failed to get watched list!" error={err} />
+{/await}

--- a/src/routes/(app)/lists/[id]/[username]/+page.svelte
+++ b/src/routes/(app)/lists/[id]/[username]/+page.svelte
@@ -21,6 +21,8 @@
   <title>{data.username}'s Watched List</title>
 </svelte:head>
 
+<h2 class="norm">{data.username}'s Watched List</h2>
+
 {#await getPublicWatchedList(Number(data.id), data.username)}
   <Spinner />
 {:then watched}
@@ -28,3 +30,11 @@
 {:catch err}
   <PageError pretty="Failed to get watched list!" error={err} />
 {/await}
+
+<style lang="scss">
+  h2 {
+    display: flex;
+    justify-content: center;
+    margin: 20px 30px;
+  }
+</style>

--- a/src/routes/(app)/lists/[id]/[username]/+page.ts
+++ b/src/routes/(app)/lists/[id]/[username]/+page.ts
@@ -1,0 +1,15 @@
+import { error } from "@sveltejs/kit";
+
+export async function load({ params }) {
+  const { id, username } = params;
+
+  if (!id || !username) {
+    error(400);
+    return;
+  }
+
+  return {
+    id,
+    username
+  };
+}

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -11,6 +11,8 @@
   $: settings = $userSettings;
   $: selectedTheme = $appTheme;
 
+  let privateDisabled = false;
+
   async function getProfile() {
     return (await axios.get(`/profile`)).data as Profile;
   }
@@ -75,7 +77,16 @@
           <h4 class="norm">Private</h4>
           <h5 class="norm">Hide your profile from others?</h5>
         </div>
-        <Checkbox value={settings.private} toggled={(on) => updateUserSetting("private", on)} />
+        <Checkbox
+          disabled={privateDisabled}
+          value={settings.private}
+          toggled={(on) => {
+            privateDisabled = true;
+            updateUserSetting("private", on, () => {
+              privateDisabled = false;
+            });
+          }}
+        />
       </div>
     </div>
   </div>

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Checkbox from "@/lib/Checkbox.svelte";
   import Error from "@/lib/Error.svelte";
   import Spinner from "@/lib/Spinner.svelte";
   import { getOrdinalSuffix, monthsShort, toggleTheme } from "@/lib/util/helpers";
@@ -47,22 +48,32 @@
     <div class="settings">
       <h3 class="norm">Settings</h3>
 
-      <h4 class="norm">Theme</h4>
       <div class="theme">
-        <button
-          class={`plain${selectedTheme === "light" ? " selected" : ""}`}
-          id="light"
-          on:click={() => toggleTheme("light")}
-        >
-          light
-        </button>
-        <button
-          class={`plain${selectedTheme === "dark" ? " selected" : ""}`}
-          id="dark"
-          on:click={() => toggleTheme("dark")}
-        >
-          dark
-        </button>
+        <h4 class="norm">Theme</h4>
+        <div class="row">
+          <button
+            class={`plain${selectedTheme === "light" ? " selected" : ""}`}
+            id="light"
+            on:click={() => toggleTheme("light")}
+          >
+            light
+          </button>
+          <button
+            class={`plain${selectedTheme === "dark" ? " selected" : ""}`}
+            id="dark"
+            on:click={() => toggleTheme("dark")}
+          >
+            dark
+          </button>
+        </div>
+      </div>
+
+      <div class="row">
+        <div>
+          <h4 class="norm">Private</h4>
+          <h5 class="norm">Hide your profile from others?</h5>
+        </div>
+        <Checkbox />
       </div>
     </div>
   </div>
@@ -126,25 +137,40 @@
   .settings {
     display: flex;
     flex-flow: column;
+    gap: 20px;
     width: 100%;
 
     h3 {
-      margin-bottom: 15px;
       font-variant: small-caps;
     }
 
-    h4 {
-      margin-bottom: 0px;
-      margin-left: 15px;
+    h5 {
+      font-weight: normal;
+    }
+
+    & > div {
+      margin: 0 15px;
+    }
+
+    div {
+      &.row {
+        display: flex;
+        flex-flow: row;
+        gap: 10px;
+        align-items: center;
+
+        & > div:first-of-type {
+          margin-right: auto;
+        }
+      }
     }
 
     .theme {
       display: flex;
+      flex-flow: column;
       gap: 10px;
-      margin: 20px;
-      margin-top: 15px;
 
-      & > button {
+      & button {
         width: 50%;
         height: 80px;
         border-radius: 10px;

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -2,11 +2,13 @@
   import Checkbox from "@/lib/Checkbox.svelte";
   import Error from "@/lib/Error.svelte";
   import Spinner from "@/lib/Spinner.svelte";
+  import { updateUserSetting } from "@/lib/util/api";
   import { getOrdinalSuffix, monthsShort, toggleTheme } from "@/lib/util/helpers";
-  import { appTheme } from "@/store";
+  import { appTheme, userSettings } from "@/store";
   import type { Profile } from "@/types";
   import axios from "axios";
 
+  $: settings = $userSettings;
   $: selectedTheme = $appTheme;
 
   async function getProfile() {
@@ -73,7 +75,7 @@
           <h4 class="norm">Private</h4>
           <h5 class="norm">Hide your profile from others?</h5>
         </div>
-        <Checkbox />
+        <Checkbox value={settings.private} toggled={(on) => updateUserSetting("private", on)} />
       </div>
     </div>
   </div>

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -26,7 +26,7 @@
 
 <div class="content">
   <div class="inner">
-    <h2>Hey {localStorage.getItem("username")}</h2>
+    <h2 title={localStorage.getItem("username")}>Hey {localStorage.getItem("username")}</h2>
 
     <div class="stats">
       {#await getProfile()}
@@ -102,6 +102,13 @@
     .inner {
       min-width: 400px;
       max-width: 400px;
+      overflow: hidden;
+
+      h2 {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
 
       & > div:not(:first-of-type) {
         margin-top: 30px;

--- a/src/routes/(app)/search/[query]/+page.svelte
+++ b/src/routes/(app)/search/[query]/+page.svelte
@@ -9,6 +9,8 @@
   import axios from "axios";
   import { getWatchedDependedProps } from "@/lib/util/helpers";
   import PersonPoster from "@/lib/PersonPoster.svelte";
+  import type { PublicUser } from "@/types";
+  import UsersList from "@/lib/UsersList.svelte";
 
   export let data;
 
@@ -17,6 +19,10 @@
   async function search(query: string) {
     return (await axios.get(`/content/${query}`)).data as ContentSearch;
   }
+
+  async function searchUsers(query: string) {
+    return (await axios.get(`/user/search/${query}`)).data as PublicUser[];
+  }
 </script>
 
 <svelte:head>
@@ -24,6 +30,14 @@
 </svelte:head>
 
 {#if data.slug}
+  {#await searchUsers(data.slug) then results}
+    {#if results?.length > 0}
+      <UsersList users={results} />
+    {/if}
+  {:catch err}
+    <PageError pretty="Failed to load watched list!" error={err} />
+  {/await}
+
   {#await search(data.slug)}
     <Spinner />
   {:then results}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,7 +19,7 @@
       {#if n.type === "loading"}
         <SpinnerTiny />
       {/if}
-      <span>{n.text}</span>
+      <span>{@html n.text}</span>
       <button
         class="plain"
         on:click={() => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,9 +1,10 @@
 import { writable } from "svelte/store";
-import type { Theme, Watched } from "./types";
+import type { Theme, UserSettings, Watched } from "./types";
 import type { Notification } from "./lib/util/notify";
 import { browser } from "$app/environment";
 import { toggleTheme } from "./lib/util/helpers";
 
+export const userSettings = writable<UserSettings>();
 export const watchedList = writable<Watched[]>([]);
 export const notifications = writable<Notification[]>([]);
 export const activeFilter = writable<string[]>(["DATEADDED", "DOWN"]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,10 @@ export interface Profile {
   moviesWatched: number;
 }
 
+export interface UserSettings {
+  private: boolean;
+}
+
 export interface JellyfinFoundContent {
   hasContent: boolean;
   url: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,12 @@ export interface AvailableAuthProviders {
   signupEnabled: boolean;
 }
 
+export interface TokenClaims {
+  userId: number;
+  username: string;
+  type: number;
+}
+
 export interface TMDBContentDetails {
   id: number;
   backdrop_path: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,12 @@ export interface UserSettings {
   private: boolean;
 }
 
+// What the user search returns
+export interface PublicUser {
+  id: number;
+  username: string;
+}
+
 export interface JellyfinFoundContent {
   hasContent: boolean;
   url: string;

--- a/src/vars.scss
+++ b/src/vars.scss
@@ -22,6 +22,8 @@ $accent-color: var(--accent-color);
 $backdrop-filter: var(--backdrop-filter);
 $backdrop-mix-blend-mode: var(--backdrop-mix-blend-mode);
 $backdrop-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 80%, rgba(0, 0, 0, 0));
+$error: #f3555a;
+$success: #28a745;
 
 // For ratings that are on bg-color.
 $rating-color: var(--rating-color);

--- a/src/vars.scss
+++ b/src/vars.scss
@@ -2,6 +2,7 @@
   --bg-color: white;
   --text-color: black;
   --accent-color: rgba(128, 128, 128, 0.226);
+  --accent-color-hover: rgba(46, 46, 46);
   --backdrop-filter: blur(4px) grayscale(80%);
   --backdrop-mix-blend-mode: multiply;
   --rating-color: black;
@@ -11,6 +12,7 @@
   --bg-color: rgb(15, 15, 15);
   --text-color: white;
   --accent-color: rgba(46, 46, 46);
+  --accent-color-hover: rgba(128, 128, 128, 0.226);
   --backdrop-filter: blur(0.5px) grayscale(50%);
   --backdrop-mix-blend-mode: difference;
   --rating-color: gold;
@@ -19,6 +21,7 @@
 $bg-color: var(--bg-color);
 $text-color: var(--text-color);
 $accent-color: var(--accent-color);
+$accent-color-hover: var(--accent-color-hover);
 $backdrop-filter: var(--backdrop-filter);
 $backdrop-mix-blend-mode: var(--backdrop-mix-blend-mode);
 $backdrop-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 80%, rgba(0, 0, 0, 0));


### PR DESCRIPTION
- When searching, if a user is found with a username LIKE the search query, they are displayed at the top of the results.
- Clicking a user result will take you to their watched list.
- Added a new setting, `private`, which when toggled, will remove your profile from displaying in search results.
- Added `Share List` button to nav face menu (copies link to clipboard).

Closes #100 