### PR TITLE
Do not fail on `.env` file missing

### DIFF
--- a/server/watcharr.go
+++ b/server/watcharr.go
@@ -35,7 +35,10 @@ var (
 func main() {
 	err := godotenv.Load()
 	if err != nil {
-		log.Fatal("Failed to load vars from .env file:", err)
+		// Do not fail if file does not exist
+		if !os.IsNotExist(err) {
+			log.Fatal("Failed to load vars from .env file:", err)
+		}
 	}
 
 	multiw := setupLogging()


### PR DESCRIPTION
In setups where you set the env vars directly, eg Docker or Kubernetes, there is no need to require a .env file

There already the `ensureEnv` below that makes sure required variables are there,