### PR TITLE
Fix import page loading without auth

### DIFF
--- a/src/routes/(app)/import/+page.svelte
+++ b/src/routes/(app)/import/+page.svelte
@@ -71,6 +71,9 @@
   }
 
   onMount(() => {
+    if (!localStorage.getItem("token")) {
+      goto("/login");
+    }
     if (fileInput) {
       fileInput.addEventListener("change", (ev) => {
         processFiles(fileInput.files);


### PR DESCRIPTION
The goto in import/process will still run after the first goto we run in the layout file if theres no token, so it's possible to end up on /import if you navigate to /import/process first.

added quick fix

closes #127 