### PR TITLE
Content: Fix play on jellyfin btn

### DIFF
--- a/src/norm.scss
+++ b/src/norm.scss
@@ -74,7 +74,8 @@
   cursor: pointer;
 }
 
-:global(button:not(.plain)) {
+:global(button:not(.plain)),
+:global(a.btn) {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/routes/(app)/movie/[id]/+page.svelte
+++ b/src/routes/(app)/movie/[id]/+page.svelte
@@ -114,8 +114,8 @@
                 {/if}
               {/if}
               {#if jellyfinUrl}
-                <a href={jellyfinUrl} target="_blank">
-                  <button><Icon i="jellyfin" wh={14} />Play On Jellyfin</button>
+                <a class="btn" href={jellyfinUrl} target="_blank">
+                  <Icon i="jellyfin" wh={14} />Play On Jellyfin
                 </a>
               {/if}
             </div>
@@ -255,6 +255,7 @@
           gap: 8px;
           margin-top: 18px;
 
+          a.btn,
           button {
             max-width: fit-content;
             overflow: hidden;
@@ -262,6 +263,7 @@
             white-space: nowrap;
             gap: 6px;
             justify-content: flex-start;
+            font-size: 14px;
 
             @keyframes otherbtn {
               from {

--- a/src/routes/(app)/tv/[id]/+page.svelte
+++ b/src/routes/(app)/tv/[id]/+page.svelte
@@ -113,8 +113,8 @@
                 {/if}
               {/if}
               {#if jellyfinUrl}
-                <a href={jellyfinUrl} target="_blank">
-                  <button><Icon i="jellyfin" wh={14} />Play On Jellyfin</button>
+                <a class="btn" href={jellyfinUrl} target="_blank">
+                  <Icon i="jellyfin" wh={14} />Play On Jellyfin
                 </a>
               {/if}
             </div>
@@ -261,6 +261,7 @@
           gap: 8px;
           margin-top: 18px;
 
+          a.btn,
           button {
             max-width: fit-content;
             overflow: hidden;
@@ -268,6 +269,7 @@
             white-space: nowrap;
             gap: 6px;
             justify-content: flex-start;
+            font-size: 14px;
 
             @keyframes otherbtn {
               from {


### PR DESCRIPTION
Works on librewolf but not firefox esr.. not sure exactly why.

We can now just add the `btn` class to a tags to get a button like link, without having to nest a `button` tag.