### PR TITLE
Poster: Fix big scrollbars making icons small in sub menus on chromium

### DIFF
--- a/src/lib/Poster.svelte
+++ b/src/lib/Poster.svelte
@@ -163,7 +163,7 @@
               {rating ? rating : disableInteraction ? "Unrated" : "Rate"}
             </span>
             {#if ratingsShown}
-              <div>
+              <div class="small-scrollbar">
                 {#each [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] as v}
                   <button
                     class="plain{rating === v ? ' active' : ''}"
@@ -195,7 +195,7 @@
               <span class="no-icon">+</span>
             {/if}
             {#if statusesShown}
-              <div>
+              <div class="small-scrollbar">
                 {#each Object.entries(watchedStatuses) as [statusName, icon]}
                   <button
                     class="plain{status && status !== statusName ? ' not-active' : ''}"

--- a/src/norm.scss
+++ b/src/norm.scss
@@ -232,4 +232,20 @@
       }
     }
   }
+
+  .small-scrollbar {
+    &::-webkit-scrollbar {
+      width: 4.5px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: rgba(155, 155, 155, 0.5);
+      border-radius: 20px;
+      border: transparent;
+    }
+  }
 }


### PR DESCRIPTION
Chromium doesn't support `scrollbar-width`, so a new css class has been made to customize the scrollbar width directly.