### PR TITLE
SeasonsList: Make season buttons wrap

### DIFF
--- a/src/lib/SeasonsList.svelte
+++ b/src/lib/SeasonsList.svelte
@@ -218,12 +218,14 @@
     button {
       display: flex;
       flex-flow: row;
-      gap: 18px;
+      flex-wrap: wrap;
+      gap: 0 18px;
       align-items: center;
       padding: 10px;
       border: 2px solid #302d2d;
       border-radius: 8px;
       cursor: pointer;
+      max-width: 220px;
       transition: background-color 100ms ease;
 
       &:first-of-type {
@@ -233,7 +235,6 @@
       h1 {
         font-size: 18px;
         font-family: sans-serif;
-        max-width: 150px;
       }
 
       h2 {


### PR DESCRIPTION
Seasons with names will take up less vertical space and look better generally.

**OLD** -> **NEW**

![image](https://github.com/sbondCo/Watcharr/assets/37304121/0579588c-249e-4736-80d3-6fa94db9f16b) ![image](https://github.com/sbondCo/Watcharr/assets/37304121/3d342441-1f5f-4b07-b3e4-45af88c445a1)
