### PR TITLE
Fix tooltip and nav overflow

### DIFF
--- a/src/norm.scss
+++ b/src/norm.scss
@@ -150,7 +150,7 @@
 
 :global(#tooltip) {
   visibility: hidden;
-  position: absolute;
+  position: fixed;
   padding: 8px 5px;
   background-color: black;
   color: white;

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -319,7 +319,7 @@
         width: 40px;
       }
 
-      @media screen and (max-width: 580px) {
+      @media screen and (max-width: 620px) {
         span.large {
           display: none;
         }
@@ -444,7 +444,7 @@
       }
     }
 
-    @media screen and (max-width: 580px) {
+    @media screen and (max-width: 666px) {
       input {
         width: 100%;
 


### PR DESCRIPTION
Fixed tooltip overflow, when hovered, then window resized to leave tooltip outside of new window bounds.
Fixed nav icon overflow - since adding more icons, had to increase the max-widths on media queries.

Closes #252 