### PR TITLE
Fix tooltips on scroll and from causing overflow on window resize

### DIFF
--- a/src/norm.scss
+++ b/src/norm.scss
@@ -150,7 +150,7 @@
 
 :global(#tooltip) {
   visibility: hidden;
-  position: fixed;
+  position: absolute;
   padding: 8px 5px;
   background-color: black;
   color: white;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
   import SpinnerTiny from "@/lib/SpinnerTiny.svelte";
   import { unNotify } from "@/lib/util/notify";
   import { notifications } from "@/store";
+  import { onMount } from "svelte";
   import { pwaInfo } from "virtual:pwa-info";
 
   $: notifs = $notifications;
@@ -11,6 +12,22 @@
     `%cWATCHARR v${__WATCHARR_VERSION__}`,
     "background: white;color: black;font-size: large;padding: 3px 5px;"
   );
+
+  function resetTooltipPos() {
+    const t = document.getElementById("tooltip");
+    if (t) {
+      t.style.top = "0";
+      t.style.left = "0";
+    }
+  }
+
+  onMount(() => {
+    window.addEventListener("resize", resetTooltipPos);
+
+    return () => {
+      window.removeEventListener("resize", resetTooltipPos);
+    };
+  });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
- Fix tooltips in wrong pos when scrolled down page
- Fix tooltips causing overflow on page if window is resized smaller than when last tooltip was.