### PR TITLE
Content rating text follow hovered star

### DIFF
--- a/src/lib/Rating.svelte
+++ b/src/lib/Rating.svelte
@@ -4,6 +4,8 @@
 
   let hoveredRating: number | undefined;
   let shownRating: number | undefined;
+  let ratingContainer: HTMLDivElement;
+  let ratingText: HTMLSpanElement;
 
   const ratingDesc = [
     "Apalling",
@@ -28,17 +30,27 @@
     else shownRating = undefined;
   }
 
-  function handleStarHover(r: number) {
+  function handleStarHover(
+    ev: MouseEvent & {
+      currentTarget: EventTarget & HTMLButtonElement;
+    },
+    r: number
+  ) {
     hoveredRating = r;
+    const start = ratingContainer?.getBoundingClientRect()?.x;
+    const starl = ev?.currentTarget?.getBoundingClientRect()?.left;
+    const rb = ratingText?.getBoundingClientRect();
+    ratingText.style.left = `${starl - start - rb.width / 2 + 10}px`;
   }
 
   function handleStarHoverEnd() {
     hoveredRating = undefined;
+    ratingText.style.left = `${0}px`;
   }
 </script>
 
-<div class="rating-container">
-  <span>
+<div class="rating-container" bind:this={ratingContainer}>
+  <span bind:this={ratingText}>
     {#if typeof hoveredRating === "number"}
       {ratingDesc[hoveredRating - 1]}
     {:else if typeof rating === "number" && rating > 0}
@@ -52,7 +64,7 @@
       <button
         class="plain{shownRating === v ? ' lit' : ''}"
         on:click={() => handleStarClick(v)}
-        on:mouseenter={() => handleStarHover(v)}
+        on:mouseenter={(ev) => handleStarHover(ev, v)}
         on:mouseleave={() => handleStarHoverEnd()}
       >
         *
@@ -65,6 +77,13 @@
   .rating-container {
     display: flex;
     flex-flow: column;
+    overflow: visible;
+
+    & > span {
+      position: relative;
+      transition: left 100ms ease-in;
+      text-align: center;
+    }
   }
 
   .rating {

--- a/src/lib/Rating.svelte
+++ b/src/lib/Rating.svelte
@@ -93,7 +93,9 @@
 
     & > span {
       position: relative;
-      transition: left 100ms ease-in;
+      transition:
+        left 100ms ease-in,
+        transform 100ms ease-in;
       max-width: max-content;
       left: 50%;
       transform: translateX(-50%);

--- a/src/lib/Rating.svelte
+++ b/src/lib/Rating.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount } from "svelte";
+
   export let rating: number | undefined;
   export let onChange: (newRating: number) => void;
 
@@ -30,6 +32,14 @@
     else shownRating = undefined;
   }
 
+  function resetRatingText() {
+    if (typeof rating === "number" && rating > 0) {
+      ratingText.innerText = ratingDesc[rating - 1];
+    } else {
+      ratingText.innerText = "Select Your Rating";
+    }
+  }
+
   function handleStarHover(
     ev: MouseEvent & {
       currentTarget: EventTarget & HTMLButtonElement;
@@ -37,28 +47,30 @@
     r: number
   ) {
     hoveredRating = r;
+    // We set innerText instead of letting svelte update dom for us
+    // since we need the new width of span right now.
+    ratingText.innerText = ratingDesc[r - 1];
     const start = ratingContainer?.getBoundingClientRect()?.x;
     const starl = ev?.currentTarget?.getBoundingClientRect()?.left;
     const rb = ratingText?.getBoundingClientRect();
-    ratingText.style.left = `${starl - start - rb.width / 2 + 10}px`;
+    ratingText.style.left = `${starl - start - rb.width / 2 + 11.5}px`;
+    ratingText.style.transform = "unset";
   }
 
   function handleStarHoverEnd() {
     hoveredRating = undefined;
-    ratingText.style.left = `${0}px`;
+    ratingText.style.left = "50%";
+    ratingText.style.transform = "translateX(-50%)";
+    resetRatingText();
   }
+
+  onMount(() => {
+    resetRatingText();
+  });
 </script>
 
 <div class="rating-container" bind:this={ratingContainer}>
-  <span bind:this={ratingText}>
-    {#if typeof hoveredRating === "number"}
-      {ratingDesc[hoveredRating - 1]}
-    {:else if typeof rating === "number" && rating > 0}
-      {ratingDesc[rating - 1]}
-    {:else}
-      Select Your Rating
-    {/if}
-  </span>
+  <span bind:this={ratingText}></span>
   <div class="rating">
     {#each [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] as v}
       <button
@@ -82,7 +94,9 @@
     & > span {
       position: relative;
       transition: left 100ms ease-in;
-      text-align: center;
+      max-width: max-content;
+      left: 50%;
+      transform: translateX(-50%);
     }
   }
 


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

<!-- Describe changes made here. If changes are visual a screenshot could be useful! -->
Center rating text by default and make it follow the hovered star.

![image](https://github.com/sbondCo/Watcharr/assets/37304121/81e55a6d-1e22-44f6-8946-ec7eb3b29766)

![image](https://github.com/sbondCo/Watcharr/assets/37304121/bc5477af-83e5-4eca-af02-9962f6c7c69c)
