### PR TITLE
API keys support on the backend

### DIFF
--- a/server/apikeys.go
+++ b/server/apikeys.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type ApiKey struct {
+	ID        uint      `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time `json:"createdAt"`
+	Value     string    `gorm:"not null" json:"value"`
+	UserID    uint      `gorm:"not null" json:"-"`
+	Note      string    `gorm:"not null" json:"note"`
+}
+
+type ApiKeyRequest struct {
+	Note string `json:"note,required"`
+}
+
+func (b *BaseRouter) addAPIKeyRoutes() {
+	apiKeyGrp := b.rg.Group("/apikeys").Use(AuthRequired(nil))
+
+	apiKeyGrp.POST("", func(ctx *gin.Context) {
+		var req ApiKeyRequest
+		if err := ctx.ShouldBindJSON(&req); err != nil {
+			ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+				"error": "'note' field is required",
+			})
+			return
+		}
+
+		userId := ctx.MustGet("userId").(uint)
+		token, err := generateString(32)
+		if err != nil {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": "unable to generate an API key",
+			})
+			return
+		}
+
+		apiKey := ApiKey{
+			Value:  token,
+			UserID: userId,
+			Note:   req.Note,
+		}
+
+		if res := b.db.Create(&apiKey); res.Error != nil {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": "unable to add API key",
+			})
+			return
+		}
+
+		ctx.JSON(http.StatusOK, apiKey)
+	})
+
+	apiKeyGrp.GET("", func(ctx *gin.Context) {
+		userId := ctx.MustGet("userId").(uint)
+
+		apiKeys := new([]ApiKey)
+		if res := b.db.Model(&ApiKey{}).Where("user_id = ?", userId).Find(&apiKeys); res.Error != nil {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": "unable to add API key",
+			})
+			return
+		}
+
+		ctx.JSON(http.StatusOK, apiKeys)
+	})
+
+	apiKeyGrp.GET("/:id", func(ctx *gin.Context) {
+		userId := ctx.MustGet("userId").(uint)
+
+		var apiKey ApiKey
+		if res := b.db.Model(&ApiKey{}).Where("user_id = ?", userId).Where("id = ?", ctx.Params.ByName("id")).First(&apiKey); res.Error != nil {
+			if res.Error == gorm.ErrRecordNotFound {
+				ctx.AbortWithStatus(http.StatusNotFound)
+				return
+			}
+
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": "unable to add API key",
+			})
+			return
+		}
+
+		ctx.JSON(http.StatusOK, apiKey)
+	})
+
+	apiKeyGrp.DELETE("/:id", func(ctx *gin.Context) {
+		userId := ctx.MustGet("userId").(uint)
+
+		if res := b.db.Model(&ApiKey{}).Where("user_id = ?", userId).Where("id = ?", ctx.Params.ByName("id")).Delete(&ApiKey{}); res.Error != nil {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": "unable to add API key",
+			})
+			return
+		}
+
+		ctx.Status(http.StatusNoContent)
+	})
+}
+
+func APIKeyMiddlewareWrapper(db *gorm.DB, mw gin.HandlerFunc) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		slog.Debug("API Key middleware hit")
+		key := ctx.GetHeader("x-api-key")
+		if key == "" {
+			mw(ctx)
+			return
+		}
+
+		var apiKey ApiKey
+
+		result := db.
+			Model(&ApiKey{}).
+			Where("value = ?", key).
+			First(&apiKey)
+
+		if result.Error != nil {
+			if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+				ctx.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+
+			ctx.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
+
+		ctx.Set("userId", apiKey.UserID)
+		ctx.Next()
+	}
+}

--- a/server/apikeys.go
+++ b/server/apikeys.go
@@ -19,120 +19,59 @@ type ApiKey struct {
 }
 
 type ApiKeyRequest struct {
-	Note string `json:"note,required"`
+	Note string `json:"note" binding:"required"`
 }
 
-func (b *BaseRouter) addAPIKeyRoutes() {
-	apiKeyGrp := b.rg.Group("/apikeys").Use(AuthRequired(nil))
-
-	apiKeyGrp.POST("", func(ctx *gin.Context) {
-		var req ApiKeyRequest
-		if err := ctx.ShouldBindJSON(&req); err != nil {
-			ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
-				"error": "'note' field is required",
-			})
-			return
-		}
-
-		userId := ctx.MustGet("userId").(uint)
-		token, err := generateString(32)
-		if err != nil {
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error": "unable to generate an API key",
-			})
-			return
-		}
-
-		apiKey := ApiKey{
-			Value:  token,
-			UserID: userId,
-			Note:   req.Note,
-		}
-
-		if res := b.db.Create(&apiKey); res.Error != nil {
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error": "unable to add API key",
-			})
-			return
-		}
-
-		ctx.JSON(http.StatusOK, apiKey)
-	})
-
-	apiKeyGrp.GET("", func(ctx *gin.Context) {
-		userId := ctx.MustGet("userId").(uint)
-
-		apiKeys := new([]ApiKey)
-		if res := b.db.Model(&ApiKey{}).Where("user_id = ?", userId).Find(&apiKeys); res.Error != nil {
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error": "unable to add API key",
-			})
-			return
-		}
-
-		ctx.JSON(http.StatusOK, apiKeys)
-	})
-
-	apiKeyGrp.GET("/:id", func(ctx *gin.Context) {
-		userId := ctx.MustGet("userId").(uint)
-
-		var apiKey ApiKey
-		if res := b.db.Model(&ApiKey{}).Where("user_id = ?", userId).Where("id = ?", ctx.Params.ByName("id")).First(&apiKey); res.Error != nil {
-			if res.Error == gorm.ErrRecordNotFound {
-				ctx.AbortWithStatus(http.StatusNotFound)
-				return
-			}
-
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error": "unable to add API key",
-			})
-			return
-		}
-
-		ctx.JSON(http.StatusOK, apiKey)
-	})
-
-	apiKeyGrp.DELETE("/:id", func(ctx *gin.Context) {
-		userId := ctx.MustGet("userId").(uint)
-
-		if res := b.db.Model(&ApiKey{}).Where("user_id = ?", userId).Where("id = ?", ctx.Params.ByName("id")).Delete(&ApiKey{}); res.Error != nil {
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error": "unable to add API key",
-			})
-			return
-		}
-
-		ctx.Status(http.StatusNoContent)
-	})
-}
-
-func APIKeyMiddlewareWrapper(db *gorm.DB, mw gin.HandlerFunc) gin.HandlerFunc {
-	return func(ctx *gin.Context) {
-		slog.Debug("API Key middleware hit")
-		key := ctx.GetHeader("x-api-key")
-		if key == "" {
-			mw(ctx)
-			return
-		}
-
-		var apiKey ApiKey
-
-		result := db.
-			Model(&ApiKey{}).
-			Where("value = ?", key).
-			First(&apiKey)
-
-		if result.Error != nil {
-			if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-				ctx.AbortWithStatus(http.StatusUnauthorized)
-				return
-			}
-
-			ctx.AbortWithStatus(http.StatusInternalServerError)
-			return
-		}
-
-		ctx.Set("userId", apiKey.UserID)
-		ctx.Next()
+func createAPIKey(db *gorm.DB, userId uint, note string) (*ApiKey, error) {
+	token, err := generateString(32)
+	if err != nil {
+		return nil, err
 	}
+
+	apiKey := ApiKey{
+		Value:  token,
+		UserID: userId,
+		Note:   note,
+	}
+
+	res := db.Create(&apiKey)
+	return &apiKey, res.Error
+}
+
+func getAllAPIKeys(db *gorm.DB, userId uint) ([]ApiKey, error) {
+	apiKeys := new([]ApiKey)
+	res := db.Model(&ApiKey{}).Where("user_id = ?", userId).Find(&apiKeys)
+	return *apiKeys, res.Error
+}
+
+func getAPIKey(db *gorm.DB, userId uint, apiKeyId string) (*ApiKey, error) {
+	var apiKey ApiKey
+	res := db.Model(&ApiKey{}).Where("user_id = ?", userId).Where("id = ?", apiKeyId).First(&apiKey)
+	return &apiKey, res.Error
+}
+
+func deleteAPIKey(db *gorm.DB, userId uint, apiKeyId string) error {
+	res := db.Model(&ApiKey{}).Where("user_id = ?", userId).Where("id = ?", apiKeyId).Delete(&ApiKey{})
+	return res.Error
+}
+
+func APIKeyMiddleware(db *gorm.DB, key string, ctx *gin.Context) {
+	slog.Debug("API Key middleware hit")
+
+	var apiKey ApiKey
+
+	result := db.First(&apiKey, "value=?", key)
+
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			ctx.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+
+		ctx.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+
+	ctx.Set("userId", apiKey.UserID)
+	ctx.Next()
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -155,6 +155,14 @@ type UserPasswordUpdateRequest struct {
 // If db is passed, extra user info from the database will be fetched.
 func AuthRequired(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
+
+		// using the API key middleware if x-api-key header is passed
+		key := c.GetHeader("x-api-key")
+		if key != "" && c.Request.Method == "GET" && c.Request.URL.Path == "/api/watched" {
+			APIKeyMiddleware(db, key, c)
+			return
+		}
+
 		slog.Debug("AuthRequired middleware hit")
 		atoken := c.GetHeader("Authorization")
 		// Make sure auth header isn't empty

--- a/server/routes.go
+++ b/server/routes.go
@@ -325,7 +325,7 @@ func (b *BaseRouter) addGameRoutes() {
 func (b *BaseRouter) addWatchedRoutes() {
 	watched := b.rg.Group("/watched").Use(AuthRequired(nil))
 
-	watched.GET("", func(c *gin.Context) {
+	b.rg.Use(APIKeyMiddlewareWrapper(b.db, AuthRequired(nil))).GET("/watched", func(c *gin.Context) {
 		userId := c.MustGet("userId").(uint)
 		c.JSON(http.StatusOK, getWatched(b.db, userId))
 	})

--- a/server/watcharr.go
+++ b/server/watcharr.go
@@ -80,6 +80,7 @@ func main() {
 		&Follow{},
 		&Image{},
 		&Game{},
+		&ApiKey{},
 	)
 	if err != nil {
 		log.Fatal("Failed to auto migrate database:", err)
@@ -138,6 +139,7 @@ func main() {
 	br.addFeatureRoutes()
 	br.addSonarrRoutes()
 	br.addRadarrRoutes()
+	br.addAPIKeyRoutes()
 	br.rg.Static("/img", path.Join(DataPath, "img"))
 
 	go setupTasks(db)


### PR DESCRIPTION
Fixes #360 partially

### Changes made

- Added a table for API Keys
- added routes for users to be able to manage their API keys
- added a middleware to authenticate routes using API keys
- use the middleware for GET method of `/api/watched` endpoint
