### PR TITLE
Config: Don't omit SIGNUP_ENABLED when empty

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -25,7 +25,7 @@ type ServerConfig struct {
 
 	// Enable/disable signup functionality.
 	// Set to `false` to disable registering an account.
-	SIGNUP_ENABLED bool `json:",omitempty"`
+	SIGNUP_ENABLED bool
 
 	// Optional: Provide your own TMDB API Key.
 	// If unprovided, the default Watcharr API key will be used.


### PR DESCRIPTION
### Changes made

SIGNUP_ENABLED was being removed from config when set to false, then once the server restarts would be set back to default value (true).

Now it is kept in config with value of false when turned off.

Fixes #388 
