### PR TITLE
Issue #359: Importing: Support syncing Watch History and Ratings from Plex

### DIFF
--- a/server/activity.go
+++ b/server/activity.go
@@ -19,6 +19,7 @@ var (
 	THOUGHTS_REMOVED          ActivityType = "THOUGHTS_REMOVED"
 	IMPORTED_WATCHED          ActivityType = "IMPORTED_WATCHED"
 	IMPORTED_WATCHED_JF       ActivityType = "IMPORTED_WATCHED_JF"
+	IMPORTED_WATCHED_PLEX     ActivityType = "IMPORTED_WATCHED_PLEX"
 	IMPORTED_RATING           ActivityType = "IMPORTED_RATING"        // Imported rating, but with no rating acts as original import of content to old platform (where they are importing from) activity
 	IMPORTED_ADDED_WATCHED    ActivityType = "IMPORTED_ADDED_WATCHED" // Imported watched date, so we can save the original watch dates of content from users old platform (where they are importing from).
 	IMPORTED_ADDED_WATCHED_JF ActivityType = "IMPORTED_ADDED_WATCHED_JF"

--- a/server/config.go
+++ b/server/config.go
@@ -35,6 +35,10 @@ type ServerConfig struct {
 	// instance to Plex for Oauth
 	PLEX_OAUTH_ID string `json:",omitempty"`
 
+	// Optional: Server URL to identify a sync
+	// server. If null, users cannot sync play data
+	PLEX_HOST string `json:",omitempty"`
+
 	SONARR []SonarrSettings `json:",omitempty"`
 	RADARR []RadarrSettings `json:",omitempty"`
 	TWITCH game.IGDB        `json:",omitempty"`
@@ -58,6 +62,7 @@ func (c *ServerConfig) GetSafe() ServerConfig {
 		JELLYFIN_HOST:  c.JELLYFIN_HOST,
 		TMDB_KEY:       c.TMDB_KEY,
 		PLEX_OAUTH_ID:  c.PLEX_OAUTH_ID,
+		PLEX_HOST:      c.PLEX_HOST,
 		DEBUG:          c.DEBUG,
 		SONARR:         c.SONARR, // Dont act safe, this contains sonarr api key, needed for config
 		RADARR:         c.RADARR, // Dont act safe, this contains radarr api key, needed for config
@@ -137,6 +142,8 @@ func updateConfig(k string, v any) error {
 		Config.TMDB_KEY = v.(string)
 	} else if k == "PLEX_OAUTH_ID" {
 		Config.PLEX_OAUTH_ID = v.(string)
+	} else if k == "PLEX_HOST" {
+		Config.PLEX_HOST = v.(string)
 	} else if k == "DEBUG" {
 		Config.DEBUG = v.(bool)
 		setLoggingLevel()

--- a/server/content.go
+++ b/server/content.go
@@ -204,6 +204,26 @@ func searchContent(query string) (TMDBSearchMultiResponse, error) {
 	return *resp, nil
 }
 
+func searchMovie(query string, year string) (TMDBSearchMultiResponse, error) {
+	resp := new(TMDBSearchMultiResponse)
+	err := tmdbRequest("/search/movie", map[string]string{"query": query, "page": "1", "year": year}, &resp)
+	if err != nil {
+		slog.Error("Failed to complete movie search request!", "error", err.Error())
+		return TMDBSearchMultiResponse{}, errors.New("failed to complete movie search request")
+	}
+	return *resp, nil
+}
+
+func searchTvShow(query string, year string) (TMDBSearchMultiResponse, error) {
+	resp := new(TMDBSearchMultiResponse)
+	err := tmdbRequest("/search/tv", map[string]string{"query": query, "page": "1", "year": year}, &resp)
+	if err != nil {
+		slog.Error("Failed to complete tv search request!", "error", err.Error())
+		return TMDBSearchMultiResponse{}, errors.New("failed to complete tv search request")
+	}
+	return *resp, nil
+}
+
 func movieDetails(db *gorm.DB, id string, country string, rParams map[string]string) (TMDBMovieDetails, error) {
 	resp := new(TMDBMovieDetails)
 	err := tmdbRequest("/movie/"+id, rParams, &resp)

--- a/server/plex.go
+++ b/server/plex.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+)
+
+type PlexLibraryType string
+
+var (
+	MOVIES   PlexLibraryType = "movie"
+	TV_SHOWS PlexLibraryType = "show"
+)
+
+type PlexResponse struct {
+	MediaContainer PlexMediaContainer `json:"MediaContainer"`
+}
+
+type PlexMediaContainer struct {
+	Directory []PlexDirectory `json:"Directory"`
+	Metadata  []PlexMetadata  `json:"Metadata"`
+}
+
+type PlexDirectory struct {
+	Key  string `json:"key"`
+	Type string `json:"type"`
+}
+
+type PlexMetadata struct {
+	Title        string  `json:"title"`
+	Year         int32   `json:"year"`
+	ViewCount    int32   `json:"viewCount"`
+	LastViewedAt int32   `json:"lastViewedAt"`
+	UserRating   float32 `json:"userRating"`
+}
+
+// Plex access middleware, ensures user is a Plex user.
+// To be ran after AuthRequired middleware with extra data.
+func PlexAccessRequired() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userId := c.MustGet("userId").(uint)
+		slog.Debug("PlexAccessRequired middleware hit", "user_id", userId)
+		userType := c.MustGet("userType").(UserType)
+		userThirdPartyAuth := c.MustGet("userThirdPartyAuth").(string)
+		if Config.PLEX_OAUTH_ID == "" {
+			slog.Error("PlexAccessRequired: Request made to make Plex API call, but PLEX_OAUTH_ID has not been configured.")
+			c.AbortWithStatus(401)
+			return
+		}
+		if Config.PLEX_HOST == "" {
+			slog.Error("PlexAccessRequired: Request made to make Plex API call, but PLEX_HOST has not been configured.")
+			c.AbortWithStatus(401)
+			return
+		}
+		if userType != PLEX_USER {
+			slog.Error("PlexAccessRequired: User is not a Plex user..", "user_type", userType)
+			c.AbortWithStatus(401)
+			return
+		}
+		if userThirdPartyAuth == "" {
+			slog.Error("PlexAccessRequired: User has no thirdPartyAuth token..")
+			c.AbortWithStatus(401)
+			return
+		}
+	}
+}
+
+func plexAPIRequest(method string, ep string, p map[string]string, userToken string, resp interface{}) error {
+	if Config.PLEX_HOST == "" {
+		slog.Error("plexAPIRequest: PLEX_HOST not configured.")
+		return errors.New("plex sync not enabled")
+	}
+	slog.Debug("plexAPIRequest", "endpoint", ep, "params", p)
+	base, err := url.Parse(Config.PLEX_HOST)
+	if err != nil {
+		return errors.New("failed to parse api uri")
+	}
+
+	// Path params
+	base.Path += ep
+
+	// Query params
+	params := url.Values{}
+	for k, v := range p {
+		params.Add(k, v)
+	}
+
+	// Add params to url
+	base.RawQuery = params.Encode()
+
+	// Run get request
+	client := &http.Client{}
+	req, err := http.NewRequest(method, base.String(), bytes.NewBuffer([]byte{}))
+	if err != nil {
+		slog.Error("Creating request to plex failed", "error", err)
+		return errors.New("request failed")
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Pler-Token", userToken)
+	res, err := client.Do(req)
+	if err != nil {
+		slog.Error("making request to plex failed", "error", err)
+		return errors.New("request failed")
+	}
+	body, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		slog.Error("Error reading plex response", "error", err.Error())
+		return err
+	}
+	if res.StatusCode != 200 {
+		slog.Error("Plex non 200 status code", "status_code", res.StatusCode, "error", string(body))
+		return errors.New("plex non 200 status code")
+	}
+	// Unmarshal response
+	slog.Info(string(body))
+	err = json.Unmarshal([]byte(body), &resp)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func plexGetLibraries(userThirdPartyAuth string) ([]PlexDirectory, error) {
+	resp := new(PlexResponse)
+	err := plexAPIRequest("GET", "/library/sections", nil, userThirdPartyAuth, &resp)
+	if err != nil {
+		slog.Error("plexGetLibraries: Plex Libraries API request failed", "error", err)
+		return nil, errors.New("failed to get plex libraries")
+	}
+	return resp.MediaContainer.Directory, nil
+}
+
+func plexGetLibraryItems(userThirdPartyAuth string, library string) ([]PlexMetadata, error) {
+	resp := new(PlexResponse)
+	err := plexAPIRequest("GET", "/library/sections/"+library+"/all", nil, userThirdPartyAuth, &resp)
+	if err != nil {
+		slog.Error("plexGetLibraryItems: Plex Library Items API request failed", "error", err)
+		return nil, errors.New("failed to get plex library items")
+	}
+
+	return resp.MediaContainer.Metadata, nil
+}

--- a/server/plex_sync.go
+++ b/server/plex_sync.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type PlexSyncResponse struct {
+	JobId string `json:"jobId"`
+}
+
+// Perform a Plex sync.
+// Errors are added silently to the job.
+func plexSyncWatched(
+	db *gorm.DB,
+	jobId string,
+	userId uint,
+	userThirdPartyAuth string,
+) {
+	updateJobCurrentTask(jobId, userId, "fetching libraries")
+	libraries, err := plexGetLibraries(userThirdPartyAuth)
+	if err != nil {
+		addJobError(jobId, userId, "failed to get plex libraries")
+		updateJobStatus(jobId, userId, JOB_DONE)
+		return
+	}
+	for _, library := range libraries {
+		if library.Type == string(MOVIES) {
+			updateJobCurrentTask(jobId, userId, "importing movies")
+			movies, err := plexGetLibraryItems(userThirdPartyAuth, library.Key)
+			if err != nil {
+				slog.Error("Failed to fetch movies from library", "library", library.Key, "error", err)
+				addJobError(jobId, userId, "failed to fetch movies from library "+library.Key)
+				continue
+			}
+			for _, movie := range movies {
+				if movie.ViewCount == 0 && movie.UserRating == 0 {
+					// Not viewed and not rated, skip importing
+					continue
+				}
+				updateJobCurrentTask(jobId, userId, "importing movie "+movie.Title)
+				slog.Info("plexSyncWatched: Importing movie.", "movie_name", movie.Title, "user_id", userId)
+				sr, err := searchMovie(movie.Title, string(movie.Year))
+				if err != nil {
+					slog.Error("Failed to search for movie", "movie", movie.Title, "error", err)
+					addJobError(jobId, userId, "failed to search for movie "+movie.Title)
+					continue
+				}
+
+				if len(sr.Results) == 0 {
+					slog.Error("plexSyncWatched: could not find movie", "movie", movie.Title)
+					addJobError(jobId, userId, "failed to add movie "+movie.Title)
+					continue
+				}
+				// We have to assume it's the first result. Thank you Plex, for not giving better metadata
+				// In theory, we could grab the IMDB ID and cross reference it with TMDB's /movie/external_ids API,
+				// but that seems like a lot of overhead. Generally title + year is good enough.
+				match := sr.Results[0]
+				_, err = addWatched(db, userId, WatchedAddRequest{
+					Status:      FINISHED,
+					ContentID:   match.ID,
+					ContentType: MOVIE,
+					Rating:      int8(movie.UserRating),
+					WatchedDate: time.Unix(int64(movie.LastViewedAt), 0),
+				}, IMPORTED_WATCHED_PLEX)
+				if err != nil {
+					if err.Error() == "content already on watched list" {
+						slog.Error("plexSyncWatched: unique constraint hit. movie must already be on watch list", "error", err)
+						continue
+					}
+					slog.Error("plexSyncWatched: Failed to add movie as watched", "error", err)
+					addJobError(jobId, userId, "failed to add movie "+movie.Title)
+				}
+			}
+		} else if library.Type == string(TV_SHOWS) {
+			updateJobCurrentTask(jobId, userId, "importing tv shows")
+			shows, err := plexGetLibraryItems(userThirdPartyAuth, library.Key)
+			if err != nil {
+				slog.Error("Failed to fetch shows from library", "library", library.Key, "error", err)
+				addJobError(jobId, userId, "failed to fetch shows from library "+library.Key)
+				continue
+			}
+			for _, show := range shows {
+				if show.ViewCount == 0 && show.UserRating == 0 {
+					// Not viewed and not rated, skip importing
+					continue
+				}
+				updateJobCurrentTask(jobId, userId, "importing show "+show.Title)
+				slog.Info("plexSyncWatched: Importing show.", "show_name", show.Title, "user_id", userId)
+				sr, err := searchTvShow(show.Title, string(show.Year))
+				if err != nil {
+					slog.Error("Failed to search for show", "show", show.Title, "error", err)
+					addJobError(jobId, userId, "failed to search for show "+show.Title)
+					continue
+				}
+
+				if len(sr.Results) == 0 {
+					slog.Error("plexSyncWatched: could not find show", "show", show.Title)
+					addJobError(jobId, userId, "failed to add show "+show.Title)
+					continue
+				}
+
+				match := sr.Results[0]
+				_, err = addWatched(db, userId, WatchedAddRequest{
+					Status:      FINISHED,
+					ContentID:   match.ID,
+					ContentType: SHOW,
+					Rating:      int8(show.UserRating),
+					WatchedDate: time.Unix(int64(show.LastViewedAt), 0),
+				}, IMPORTED_WATCHED_PLEX)
+				if err != nil {
+					if err.Error() == "content already on watched list" {
+						slog.Error("plexSyncWatched: unique constraint hit. show must already be on watch list", "error", err)
+						continue
+					}
+					slog.Error("plexSyncWatched: Failed to add show as watched", "error", err)
+					addJobError(jobId, userId, "failed to add show "+show.Title)
+				}
+			}
+		}
+	}
+	updateJobStatus(jobId, userId, JOB_DONE)
+}
+
+func startPlexSync(
+	db *gorm.DB,
+	userId uint,
+	userThirdPartyAuth string,
+) (PlexSyncResponse, error) {
+	jobId, err := addJob("plex_sync", userId)
+	if err != nil {
+		slog.Error("startPlexSync: Failed to create a job", "error", err)
+		return PlexSyncResponse{}, errors.New("failed to create job")
+	}
+
+	updateJobStatus(jobId, userId, JOB_RUNNING)
+
+	go plexSyncWatched(
+		db,
+		jobId,
+		userId,
+		userThirdPartyAuth,
+	)
+
+	return PlexSyncResponse{JobId: jobId}, nil
+}

--- a/server/watcharr.go
+++ b/server/watcharr.go
@@ -131,6 +131,7 @@ func main() {
 	br.addActivityRoutes()
 	br.addProfileRoutes()
 	br.addJellyfinRoutes()
+	br.addPlexRoutes()
 	br.addUserRoutes()
 	br.addFollowRoutes()
 	br.addImportRoutes()

--- a/src/lib/Activity.svelte
+++ b/src/lib/Activity.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Activity } from "@/types";
   import { getOrdinalSuffix, months, seasonAndEpToReadable } from "./util/helpers";
-  import ActivityEditor from "./ActivityEditor.svelte";
+  import ActivityEditor from "../routes/(app)/profile/modals/ActivityEditor.svelte";
 
   export let activity: Activity[] | undefined;
   export let wListId: number;

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -14,7 +14,7 @@
   import { notify } from "@/lib/util/notify";
   import UserAvatar from "@/lib/img/UserAvatar.svelte";
   import PwChangeModal from "@/routes/(app)/profile/modals/PwChangeModal.svelte";
-  import JellyfinSyncModal from "./modals/JellyfinSyncModal.svelte";
+  import SyncModal from "./modals/SyncModal.svelte";
 
   $: user = $userInfo;
   $: settings = $userSettings;
@@ -28,6 +28,7 @@
   let pwChangeModalOpen = false;
   let getProfilePromise = getProfile();
   let jellyfinSyncModalOpen = false;
+  let plexSyncModalOpen = false;
 
   async function getProfile() {
     return (await axios.get(`/profile`)).data as Profile;
@@ -275,6 +276,11 @@
             Sync With Jellyfin
           </button>
         {/if}
+        {#if user?.type === UserType.Plex}
+          <button on:click={() => (plexSyncModalOpen = true)} disabled={exportDisabled}>
+            Sync with Plex
+          </button>
+        {/if}
       </div>
       {#if pwChangeModalOpen}
         <PwChangeModal
@@ -285,7 +291,18 @@
         ></PwChangeModal>
       {/if}
       {#if jellyfinSyncModalOpen}
-        <JellyfinSyncModal onClose={() => (jellyfinSyncModalOpen = false)} />
+        <SyncModal
+          title="Jellyfin Sync"
+          endpoint="/jellyfin/sync"
+          onClose={() => (jellyfinSyncModalOpen = false)}
+        />
+      {/if}
+      {#if plexSyncModalOpen}
+        <SyncModal
+          title="Plex Sync"
+          endpoint="/plex/sync"
+          onClose={() => (plexSyncModalOpen = false)}
+        />
       {/if}
     </div>
   </div>

--- a/src/routes/(app)/profile/modals/ActivityEditor.svelte
+++ b/src/routes/(app)/profile/modals/ActivityEditor.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { updateActivity, removeActivity } from "@/lib/util/api";
-  import Modal from "./Modal.svelte";
+  import Modal from "@/lib/Modal.svelte";
   import type { Activity } from "@/types";
-  import { notify } from "./util/notify";
+  import { notify } from "@/lib/util/notify";
 
   export let watchedId: number;
   export let activity: Activity;

--- a/src/routes/(app)/profile/modals/SyncModal.svelte
+++ b/src/routes/(app)/profile/modals/SyncModal.svelte
@@ -3,32 +3,34 @@
   import Modal from "@/lib/Modal.svelte";
   import Spinner from "@/lib/Spinner.svelte";
   import { notify } from "@/lib/util/notify";
-  import { JobStatus, type GetJobResponse, type JellyfinSyncResponse } from "@/types";
+  import { JobStatus, type GetJobResponse, type SyncResponse } from "@/types";
   import axios from "axios";
   import { onDestroy, onMount } from "svelte";
   import { watchedList } from "@/store";
 
   export let onClose: () => void;
+  export let title: string;
+  export let endpoint: string;
 
   let step: "starting" | "errored" | "job-running" | "done" | "modal-closing" = "starting";
   let jobId: string | undefined;
   let currentTask: string | undefined;
   let latestJobStatus: GetJobResponse | undefined;
 
-  async function startJellyfinSync() {
+  async function startSync() {
     try {
-      const r = await axios.get<JellyfinSyncResponse>("/jellyfin/sync");
-      console.log("startJellyfinSync: Response:", r.data);
+      const r = await axios.post<SyncResponse>(endpoint);
+      console.log("startSync: Response:", r.data);
       if (!r.data.jobId) {
         step = "errored";
-        console.error("startJellyfinSync: No jobId returned!");
+        console.error("startSync: No jobId returned!");
         return;
       }
       jobId = r.data.jobId;
       step = "job-running";
       startJobWatcher();
     } catch (err) {
-      console.error("startJellyfinSync failed!", err);
+      console.error("startSync failed!", err);
       step = "errored";
     }
   }
@@ -98,7 +100,7 @@
   }
 
   onMount(() => {
-    startJellyfinSync();
+    startSync();
   });
 
   onDestroy(() => {
@@ -109,7 +111,7 @@
   });
 </script>
 
-<Modal title="Jellyfin Sync" maxWidth="700px" onClose={modalClose}>
+<Modal {title} maxWidth="700px" onClose={modalClose}>
   <div class="ctr">
     {#if step === "done"}
       <Icon i="check" wh={60} />

--- a/src/routes/(app)/server/+page.svelte
+++ b/src/routes/(app)/server/+page.svelte
@@ -29,7 +29,8 @@
   let debugDisabled = false;
   let jfDisabled = false;
   let tmdbkDisabled = false;
-  let plexDisabled = false;
+  let plexOauthDisabled = false;
+  let plexHostDisabled = false;
 
   async function getServerConfig() {
     serverConfig = (await axios.get(`/server/config`)).data as ServerConfig;
@@ -151,19 +152,35 @@
         <Setting title="Plex OAuth" desc="Allow logging in via Plex" row>
           <Checkbox
             name="PLEX_OAUTH_ID"
-            disabled={plexDisabled}
+            disabled={plexOauthDisabled}
             value={serverConfig.PLEX_OAUTH_ID !== undefined &&
               serverConfig.PLEX_OAUTH_ID.length > 0}
             toggled={(on) => {
-              plexDisabled = true;
+              plexOauthDisabled = true;
               let id = "";
               if (on) {
                 id = crypto.randomUUID();
               }
               updateServerConfig("PLEX_OAUTH_ID", id, () => {
-                plexDisabled = false;
+                plexOauthDisabled = false;
               });
             }}
+          />
+        </Setting>
+        <Setting title="Plex Server URL" desc="Allow syncing server play info" row>
+          <input
+            type="text"
+            placeholder="https://plex.example.com:32400"
+            bind:value={serverConfig.PLEX_HOST}
+            on:blur={() => {
+              plexHostDisabled = true;
+              updateServerConfig("PLEX_HOST", serverConfig.PLEX_HOST, () => {
+                plexHostDisabled = false;
+              });
+            }}
+            disabled={plexHostDisabled ||
+              serverConfig.PLEX_OAUTH_ID == undefined ||
+              serverConfig.PLEX_OAUTH_ID.length == 0}
           />
         </Setting>
         <Setting title="Signup" desc="Allow signing up with web ui" row>

--- a/src/types.ts
+++ b/src/types.ts
@@ -760,6 +760,7 @@ export interface ServerConfig {
   SIGNUP_ENABLED: boolean;
   TMDB_KEY: string;
   PLEX_OAUTH_ID: string;
+  PLEX_HOST: string;
   SONARR: SonarrSettings[];
   RADARR: RadarrSettings[];
   TWITCH: TwitchSettings;
@@ -984,7 +985,7 @@ export enum GameWebsiteCategory {
   Reddit = 14
 }
 
-export interface JellyfinSyncResponse {
+export interface SyncResponse {
   jobId: string;
 }
 


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

- Generalize sync modal to work for both plex and jellyfin
- Fix plex login bug due to bad type filtering
- Update plex token on re-login to support token revoke/expiration
- Add Plex server configuration for fetching watch data
- Add TV and Movie specific TMBD APIs
- Move activity modal into modals directory

<!-- Describe changes made here. If changes are visual a screenshot could be useful! -->
