### PR TITLE
plex auth improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "axios": "^1.6.7",
         "blurhash": "^2.0.5",
-        "papaparse": "^5.4.1",
-        "plex-oauth": "^2.1.0"
+        "papaparse": "^5.4.1"
       },
       "devDependencies": {
         "@sveltejs/adapter-node": "^4.0.1",
@@ -6001,22 +6000,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/plex-oauth": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/plex-oauth/-/plex-oauth-2.1.0.tgz",
-      "integrity": "sha512-q/T/ooR7Hc1qqKN08k5x6FuVeJ2a65RBxNlnF4ug0aH3iViREp8iT3siEaI4jEFyxUmZdQaY5JLItgD+dQv4KQ==",
-      "dependencies": {
-        "axios": "^0.26.1"
-      }
-    },
-    "node_modules/plex-oauth/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "axios": "^1.6.7",
     "blurhash": "^2.0.5",
-    "papaparse": "^5.4.1",
-    "plex-oauth": "^2.1.0"
+    "papaparse": "^5.4.1"
   }
 }

--- a/server/config.go
+++ b/server/config.go
@@ -31,9 +31,14 @@ type ServerConfig struct {
 	// If unprovided, the default Watcharr API key will be used.
 	TMDB_KEY string `json:",omitempty"`
 
-	// Optional: Server key to identify this
-	// instance to Plex for Oauth
-	PLEX_OAUTH_ID string `json:",omitempty"`
+	// Optional: Point to Plex install to enable plex features.
+	PLEX_HOST string `json:",omitempty"`
+
+	// Optional: Machine identifier of your Plex server.
+	// This is used to ensure only users of your Plex server
+	// can use this Watcharr instance.
+	// Will be fetched automatically when PLEX_HOST is provided via web ui.
+	PLEX_MACHINE_ID string `json:",omitempty"`
 
 	SONARR []SonarrSettings `json:",omitempty"`
 	RADARR []RadarrSettings `json:",omitempty"`
@@ -54,13 +59,14 @@ type ServerConfig struct {
 // not editable on frontend, so not needed).
 func (c *ServerConfig) GetSafe() ServerConfig {
 	return ServerConfig{
-		SIGNUP_ENABLED: c.SIGNUP_ENABLED,
-		JELLYFIN_HOST:  c.JELLYFIN_HOST,
-		TMDB_KEY:       c.TMDB_KEY,
-		PLEX_OAUTH_ID:  c.PLEX_OAUTH_ID,
-		DEBUG:          c.DEBUG,
-		SONARR:         c.SONARR, // Dont act safe, this contains sonarr api key, needed for config
-		RADARR:         c.RADARR, // Dont act safe, this contains radarr api key, needed for config
+		SIGNUP_ENABLED:  c.SIGNUP_ENABLED,
+		JELLYFIN_HOST:   c.JELLYFIN_HOST,
+		TMDB_KEY:        c.TMDB_KEY,
+		PLEX_HOST:       c.PLEX_HOST,
+		PLEX_MACHINE_ID: c.PLEX_MACHINE_ID,
+		DEBUG:           c.DEBUG,
+		SONARR:          c.SONARR, // Dont act safe, this contains sonarr api key, needed for config
+		RADARR:          c.RADARR, // Dont act safe, this contains radarr api key, needed for config
 		TWITCH: game.IGDB{
 			ClientID:     c.TWITCH.ClientID,
 			ClientSecret: c.TWITCH.ClientSecret,
@@ -135,8 +141,6 @@ func updateConfig(k string, v any) error {
 		Config.SIGNUP_ENABLED = v.(bool)
 	} else if k == "TMDB_KEY" {
 		Config.TMDB_KEY = v.(string)
-	} else if k == "PLEX_OAUTH_ID" {
-		Config.PLEX_OAUTH_ID = v.(string)
 	} else if k == "DEBUG" {
 		Config.DEBUG = v.(bool)
 		setLoggingLevel()

--- a/server/plex.go
+++ b/server/plex.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+type PlexLoginRequest struct {
+	AuthToken string `json:"token" binding:"required"`
+}
+
+type PlexUser struct {
+	Id       uint64 `json:"id" binding:"required"`
+	Uuid     string `json:"uuid" binding:"required"`
+	Email    string `json:"email" binding:"required"`
+	Username string `json:"username" binding:"required"`
+}
+
+type PlexAccountResponse struct {
+	User PlexUser `json:"user" binding:"required"`
+}
+
+type PlexIdentity struct {
+	MediaContainer struct {
+		MachineIdentifier string `json:"machineIdentifier"`
+	} `json:"MediaContainer"`
+}
+
+type PlexHostConfigUpdateResponse struct {
+	PLEX_MACHINE_ID string
+}
+
+type PlexUsersResponse struct {
+	XMLName           xml.Name `xml:"MediaContainer"`
+	Text              string   `xml:",chardata"`
+	FriendlyName      string   `xml:"friendlyName,attr"`
+	Identifier        string   `xml:"identifier,attr"`
+	MachineIdentifier string   `xml:"machineIdentifier,attr"`
+	TotalSize         string   `xml:"totalSize,attr"`
+	Size              string   `xml:"size,attr"`
+	User              []struct {
+		Text                      string `xml:",chardata"`
+		ID                        string `xml:"id,attr"`
+		Title                     string `xml:"title,attr"`
+		Username                  string `xml:"username,attr"`
+		Email                     string `xml:"email,attr"`
+		RecommendationsPlaylistId string `xml:"recommendationsPlaylistId,attr"`
+		Thumb                     string `xml:"thumb,attr"`
+		Protected                 string `xml:"protected,attr"`
+		Home                      string `xml:"home,attr"`
+		AllowTuners               string `xml:"allowTuners,attr"`
+		AllowSync                 string `xml:"allowSync,attr"`
+		AllowCameraUpload         string `xml:"allowCameraUpload,attr"`
+		AllowChannels             string `xml:"allowChannels,attr"`
+		AllowSubtitleAdmin        string `xml:"allowSubtitleAdmin,attr"`
+		FilterAll                 string `xml:"filterAll,attr"`
+		FilterMovies              string `xml:"filterMovies,attr"`
+		FilterMusic               string `xml:"filterMusic,attr"`
+		FilterPhotos              string `xml:"filterPhotos,attr"`
+		FilterTelevision          string `xml:"filterTelevision,attr"`
+		Restricted                string `xml:"restricted,attr"`
+		Server                    []struct {
+			Text              string `xml:",chardata"`
+			ID                string `xml:"id,attr"`
+			ServerId          string `xml:"serverId,attr"`
+			MachineIdentifier string `xml:"machineIdentifier,attr"`
+			Name              string `xml:"name,attr"`
+			LastSeenAt        string `xml:"lastSeenAt,attr"`
+			NumLibraries      string `xml:"numLibraries,attr"`
+			AllLibraries      string `xml:"allLibraries,attr"`
+			Owned             string `xml:"owned,attr"`
+			Pending           string `xml:"pending,attr"`
+		} `xml:"Server"`
+	} `xml:"User"`
+}
+
+func getPlexIdentity(host string) (PlexIdentity, error) {
+	httpClient := &http.Client{}
+	req, err := http.NewRequest("GET", host+"/identity", nil)
+	if err != nil {
+		return PlexIdentity{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return PlexIdentity{}, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return PlexIdentity{}, err
+	}
+	defer resp.Body.Close()
+	var pi PlexIdentity
+	err = json.Unmarshal(body, &pi)
+	if err != nil {
+		return PlexIdentity{}, err
+	}
+	return pi, nil
+}
+
+func fetchPlexAccountFromToken(token string) (PlexUser, error) {
+	httpClient := &http.Client{}
+	req, err := http.NewRequest("GET", "https://plex.tv/users/account.json", nil)
+	if err != nil {
+		return PlexUser{}, err
+	}
+	req.Header.Set("X-Plex-Token", token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return PlexUser{}, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return PlexUser{}, err
+	}
+	slog.Info(string(body))
+	defer resp.Body.Close()
+	var pa PlexAccountResponse
+	err = json.Unmarshal(body, &pa)
+	if err != nil {
+		return PlexUser{}, err
+	}
+	return pa.User, nil
+}
+
+// Update plex host setting
+func updateConfigPlexHost(v string) (PlexHostConfigUpdateResponse, error) {
+	Config.PLEX_HOST = v
+	if Config.PLEX_HOST != "" {
+		pi, err := getPlexIdentity(Config.PLEX_HOST)
+		if err != nil {
+			slog.Error("updateConfigPlexHost: Failed to get plex server identity!", "error", err)
+			return PlexHostConfigUpdateResponse{}, errors.New("failed to get Plex server identity. Please try setting the Plex Host again or setting PLEX_MACHINE_ID manually in your config file")
+		}
+		if pi.MediaContainer.MachineIdentifier == "" {
+			slog.Error("updateConfigPlexHost: Plex server identity response had no machine id!", "response", pi)
+			return PlexHostConfigUpdateResponse{}, errors.New("got Plex server identity, but no machine id was found")
+		}
+		Config.PLEX_MACHINE_ID = pi.MediaContainer.MachineIdentifier
+	} else {
+		Config.PLEX_MACHINE_ID = ""
+	}
+	if err := writeConfig(); err != nil {
+		slog.Error("updateConfigPlexHost: Failed to write updated config to file!", "err", err)
+		return PlexHostConfigUpdateResponse{}, errors.New("failed to write config")
+	}
+	return PlexHostConfigUpdateResponse{PLEX_MACHINE_ID: Config.PLEX_MACHINE_ID}, nil
+}
+
+// If a plex user has access to our home plex server (PLEX_HOST).
+func plexUserHasAccessToPlexHost(token string) error {
+	httpClient := &http.Client{}
+	req, err := http.NewRequest("GET", "https://plex.tv/api/users", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Plex-Token", token)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var pa PlexUsersResponse
+	err = xml.Unmarshal(body, &pa)
+	if err != nil {
+		return err
+	}
+
+	if len(pa.User) <= 0 {
+		return errors.New("found no users in response")
+	}
+
+	// Now check if any of the users servers include our home server machine id
+	homeServerFound := false
+userLoop:
+	for _, user := range pa.User {
+		for _, server := range user.Server {
+			if server.MachineIdentifier == Config.PLEX_MACHINE_ID {
+				slog.Debug("plexUserHasAccessToPlexHost: Processing a server.", "server", server.MachineIdentifier)
+				homeServerFound = true
+				break userLoop
+			}
+		}
+		if homeServerFound {
+			break
+		}
+	}
+	if homeServerFound {
+		return nil
+	}
+	return errors.New("user does not have access to home plex server")
+}

--- a/src/lib/Icon.svelte
+++ b/src/lib/Icon.svelte
@@ -60,7 +60,6 @@
   </svg>
 {:else if i === "plex"}
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width={wh} height={wh}>
-    <rect width="512" height="512" rx="15%" fill="#282a2d" />
     <path d="M256 70H148l108 186-108 186h108l108-186z" fill="#e5a00d" />
   </svg>
 {:else if i === "trash"}

--- a/src/lib/Status.svelte
+++ b/src/lib/Status.svelte
@@ -62,6 +62,7 @@
 
     button {
       font-size: 10px;
+      padding: 5px 10px;
     }
   }
 </style>

--- a/src/lib/util/plex.ts
+++ b/src/lib/util/plex.ts
@@ -1,0 +1,120 @@
+import { noAuthAxios } from "./api";
+
+interface Plex {
+  win: Window;
+  headers: Record<string, string>;
+  clientId: string;
+}
+
+interface PlexPin {
+  id: number;
+  code: string;
+}
+
+//
+function uuidv4() {
+  return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c: any) =>
+    (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
+  );
+}
+
+export function preparePlexAuth(): Plex {
+  // No point making a store for this.
+  let clientId = localStorage.getItem("plex-cid");
+  if (!clientId) {
+    if (crypto.randomUUID) {
+      console.log("preparePlexAuth: Using randomUUID");
+      clientId = crypto.randomUUID();
+    } else {
+      // Use this if randomUUID is unavailable (ex in unsecure context, this use case isn't as big a deelio)
+      console.log("preparePlexAuth: Not using randomUUID");
+      clientId = uuidv4();
+    }
+    localStorage.setItem("plex-cid", clientId);
+  }
+
+  const w = 600;
+  const h = 800;
+  // Fixes dual-screen position                           Most browsers       Firefox
+  const dualScreenLeft = window.screenLeft != undefined ? window.screenLeft : window.screenX;
+  const dualScreenTop = window.screenTop != undefined ? window.screenTop : window.screenY;
+  const width = window.innerWidth
+    ? window.innerWidth
+    : document.documentElement.clientWidth
+      ? document.documentElement.clientWidth
+      : screen.width;
+  const height = window.innerHeight
+    ? window.innerHeight
+    : document.documentElement.clientHeight
+      ? document.documentElement.clientHeight
+      : screen.height;
+  const left = width / 2 - w / 2 + dualScreenLeft;
+  const top = height / 2 - h / 2 + dualScreenTop;
+
+  const win = window.open(
+    "",
+    "Continue to Watcharr With Plex",
+    `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`
+  );
+  if (win) {
+    win.focus();
+    return {
+      win,
+      // Don't really want to give all the possible headers,
+      // trying to minimize it to what gets it working.
+      headers: {
+        "X-Plex-Product": "Watcharr",
+        "X-Plex-Client-Identifier": clientId,
+        "X-Plex-Version": "Plex OAuth",
+        "X-Plex-Model": "Plex OAuth",
+        "X-Plex-Platform": "Firefox",
+        "X-Plex-Platform-Version": "123.0",
+        "X-Plex-Device": "Windows",
+        "X-Plex-Device-Name": "Watcharr"
+      },
+      clientId
+    };
+  }
+  throw new Error("Failed to prepare popup!");
+}
+
+export async function doPlexLogin({ win, headers, clientId }: Plex): Promise<PlexPin> {
+  const pin = await getPlexPin(headers);
+  win.location.href = `https://app.plex.tv/auth/#!?clientID=${clientId}&code=${pin.code}&context=Watcharr&context[device][device]=${headers["X-Plex-Device"]}&context[device][deviceName]=${headers["X-Plex-Device-Name"]}&context[device][platform]=${headers["X-Plex-Platform"]}&context[device][platformVersion]=${headers["X-Plex-Platform-Version"]}&context[device][product]=${headers["X-Plex-Product"]}`;
+  return pin;
+}
+
+export async function plexPinPoll(
+  pin: PlexPin,
+  { win, headers }: Plex,
+  done: (err?: Error, token?: string) => void
+) {
+  const doPoll = async () => {
+    try {
+      console.debug("plexPinPoll");
+      const r = await noAuthAxios.get(`https://plex.tv/api/v2/pins/${pin.id}`, {
+        headers: { ...headers, code: pin.code }
+      });
+      if (r.data?.authToken) {
+        done(undefined, r.data.authToken);
+        win.close();
+      } else if (win?.closed) {
+        done(new Error("Plex popup closed before login completed"));
+      } else {
+        setTimeout(doPoll, 1000);
+      }
+    } catch (err) {
+      console.error("plexPinPoll: Failed!", err);
+      done(new Error("Pin poll failed"));
+    }
+  };
+  setTimeout(doPoll, 1000);
+}
+
+async function getPlexPin(headers: Record<string, string>): Promise<PlexPin> {
+  const r = await noAuthAxios.post(`https://plex.tv/api/v2/pins?strong=true`, undefined, {
+    headers: headers
+  });
+  console.debug("getPlexPin:", r.data);
+  return { id: r.data.id, code: r.data.code };
+}

--- a/src/norm.scss
+++ b/src/norm.scss
@@ -56,7 +56,7 @@
 }
 
 :global(input, textarea) {
-  padding: 5px 10px;
+  padding: 7px 10px;
   border: 2px solid black;
   border-radius: 5px;
   width: 100%;
@@ -83,7 +83,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 5px 10px;
+  padding: 7px 10px;
   border: 2px solid $text-color;
   border-radius: 5px;
   background-color: $bg-color;
@@ -136,32 +136,6 @@
     &:hover,
     &:focus-visible {
       background-color: $error;
-      color: white;
-    }
-  }
-}
-
-:global(button.plex) {
-  border: 2px solid $plex;
-  color: $plex;
-
-  &:not(:disabled) {
-    &:hover,
-    &:focus-visible {
-      background-color: $plex;
-      color: white;
-    }
-  }
-}
-
-:global(button.jellyfin) {
-  border: 2px solid $jellyfin;
-  color: $jellyfin;
-
-  &:not(:disabled) {
-    &:hover,
-    &:focus-visible {
-      background-color: $jellyfin;
       color: white;
     }
   }

--- a/src/routes/(app)/server/+page.svelte
+++ b/src/routes/(app)/server/+page.svelte
@@ -29,7 +29,7 @@
   let debugDisabled = false;
   let jfDisabled = false;
   let tmdbkDisabled = false;
-  let plexDisabled = false;
+  let plexHostDisabled = false;
 
   async function getServerConfig() {
     serverConfig = (await axios.get(`/server/config`)).data as ServerConfig;
@@ -38,19 +38,23 @@
   export function updateServerConfig<K extends keyof ServerConfig>(
     name: K,
     value: ServerConfig[K],
-    done?: () => void
+    done?: (respData?: any) => void
   ) {
     console.log("Updating server setting", name, "to", value);
     const originalValue = serverConfig[name];
     const nid = notify({ type: "loading", text: "Updating" });
+    let ep = "/server/config";
+    if (name === "PLEX_HOST") {
+      ep = "/server/config/plex_host";
+    }
     axios
-      .post("/server/config", { key: name, value: value })
+      .post(ep, { key: name, value: value })
       .then((r) => {
         if (r.status === 200) {
           serverConfig[name] = value;
           serverConfig = serverConfig;
           notify({ id: nid, type: "success", text: "Updated" });
-          if (typeof done !== "undefined") done();
+          if (typeof done !== "undefined") done(r?.data);
         }
       })
       .catch((err) => {
@@ -134,6 +138,28 @@
             disabled={jfDisabled}
           />
         </Setting>
+        <Setting
+          title="Plex Host"
+          desc="Point to your Plex server to enable related features. Don't change server after
+        already using another."
+        >
+          <input
+            type="text"
+            placeholder="https://plex.example.com"
+            bind:value={serverConfig.PLEX_HOST}
+            on:blur={() => {
+              plexHostDisabled = true;
+              updateServerConfig("PLEX_HOST", serverConfig.PLEX_HOST, (rData) => {
+                plexHostDisabled = false;
+                serverConfig.PLEX_MACHINE_ID = rData?.PLEX_MACHINE_ID;
+              });
+            }}
+            disabled={plexHostDisabled}
+          />
+          {#if serverConfig.PLEX_MACHINE_ID}
+            <span style="font-size: 10px">Machine Id: {serverConfig.PLEX_MACHINE_ID}</span>
+          {/if}
+        </Setting>
         <Setting title="TMDB Key" desc="Provide your own TMDB API Key">
           <input
             type="password"
@@ -146,24 +172,6 @@
               });
             }}
             disabled={tmdbkDisabled}
-          />
-        </Setting>
-        <Setting title="Plex OAuth" desc="Allow logging in via Plex" row>
-          <Checkbox
-            name="PLEX_OAUTH_ID"
-            disabled={plexDisabled}
-            value={serverConfig.PLEX_OAUTH_ID !== undefined &&
-              serverConfig.PLEX_OAUTH_ID.length > 0}
-            toggled={(on) => {
-              plexDisabled = true;
-              let id = "";
-              if (on) {
-                id = crypto.randomUUID();
-              }
-              updateServerConfig("PLEX_OAUTH_ID", id, () => {
-                plexDisabled = false;
-              });
-            }}
           />
         </Setting>
         <Setting title="Signup" desc="Allow signing up with web ui" row>

--- a/src/types.ts
+++ b/src/types.ts
@@ -759,7 +759,8 @@ export interface ServerConfig {
   JELLYFIN_HOST: string;
   SIGNUP_ENABLED: boolean;
   TMDB_KEY: string;
-  PLEX_OAUTH_ID: string;
+  PLEX_HOST: string;
+  PLEX_MACHINE_ID: string;
   SONARR: SonarrSettings[];
   RADARR: RadarrSettings[];
   TWITCH: TwitchSettings;

--- a/src/vars.scss
+++ b/src/vars.scss
@@ -39,7 +39,6 @@ $poster-extra-detail-bg-color: rgba(46, 46, 46, 0.5);
 $error: #f3555a;
 $success: #28a745;
 $plex: #e5a00d;
-$jellyfin: #007ca6;
 
 // For ratings that are on bg-color.
 $rating-color: var(--rating-color);


### PR DESCRIPTION
### Changes made

- Our own auth flow, removed 'plex-oauth' dep.
- Fixed normal registrations
- Combined login/register plex methods
- Changed login page plex btn styling
- Reverted colors on jellyfin/plex btns (couldn't find a nice one and it hurt me)
- Removed plex client id from server config, replaced by plex host and plex machine id config items
- Plex client id is generated on the client and stored for reuse, each client will do that instead of the server storing it for everyone.
- Use plex machine id to ensure only approved users can login via plex (users with access to host server library)
- Renamed some structs and funcs
- Removed background from plex icon
- Made buttons and inputs bigger (more padding, also unrelated to rest of changed but i think it looks nice)
