### PR TITLE
Configurable data location 

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -6,13 +6,20 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"path"
 	"time"
 
 	"github.com/sbondCo/Watcharr/game"
 	"gorm.io/gorm"
 )
 
-var DataPath = "./data"
+var DataPath = func()(string) {
+  path := os.Getenv("WATCHAR_DATA")
+	if path == "" {
+    path = "./data"
+  }
+	return path
+}()
 
 type ServerConfig struct {
 	// Used to sign JWT tokens. Make sure to make
@@ -82,7 +89,7 @@ var (
 // Read config file
 // Calls generateConfig if file doesn't exist
 func readConfig() error {
-	cfg, err := os.Open("./data/watcharr.json")
+	cfg, err := os.Open(path.Join(DataPath, "watcharr.json"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			slog.Info("Config file doesn't exist... generating.")
@@ -126,7 +133,7 @@ func generateConfig() error {
 		return err
 	}
 	Config = cfg
-	return os.WriteFile("./data/watcharr.json", barej, 0755)
+	return os.WriteFile(path.Join(DataPath, "watcharr.json"), barej, 0755)
 }
 
 // Update server config property
@@ -156,7 +163,7 @@ func writeConfig() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile("./data/watcharr.json", barej, 0755)
+	return os.WriteFile(path.Join(DataPath, "watcharr.json"), barej, 0755)
 }
 
 type ServerFeatures struct {

--- a/server/config.go
+++ b/server/config.go
@@ -13,11 +13,11 @@ import (
 	"gorm.io/gorm"
 )
 
-var DataPath = func()(string) {
-  path := os.Getenv("WATCHAR_DATA")
+var DataPath = func() string {
+	path := os.Getenv("WATCHARR_DATA")
 	if path == "" {
-    path = "./data"
-  }
+		path = "./data"
+	}
 	return path
 }()
 

--- a/server/content.go
+++ b/server/content.go
@@ -85,7 +85,7 @@ func saveContent(db *gorm.DB, c *Content, onlyUpdate bool) error {
 	// If row created, download the image
 	if res.RowsAffected > 0 {
 		slog.Debug("saveContent: Downloading poster.")
-		err := download("https://image.tmdb.org/t/p/w500"+c.PosterPath, path.Join("./data/img", c.PosterPath))
+		err := download("https://image.tmdb.org/t/p/w500"+c.PosterPath, path.Join(DataPath, "img", c.PosterPath))
 		if err != nil {
 			slog.Error("saveContent: Failed to download content image!", "error", err.Error())
 		}

--- a/server/watcharr.go
+++ b/server/watcharr.go
@@ -52,7 +52,7 @@ func main() {
 	setLoggingLevel()
 
 	// Ensure data dir exists
-	err = ensureDirExists("./data")
+	err = ensureDirExists(DataPath)
 	if err != nil {
 		log.Fatal("Failed to create data dir:", err)
 	}
@@ -64,7 +64,7 @@ func main() {
 		isProd = false
 	}
 
-	db, err := gorm.Open(sqlite.Open("./data/watcharr.db"), &gorm.Config{TranslateError: true})
+	db, err := gorm.Open(sqlite.Open(path.Join(DataPath, "watcharr.db")), &gorm.Config{TranslateError: true})
 	if err != nil {
 		log.Fatal("Failed to connect to database:", err)
 	}
@@ -152,7 +152,7 @@ func main() {
 func setupLogging() io.Writer {
 	// logLevel = new(slog.LevelVar)
 	multiw := io.MultiWriter(&lumberjack.Logger{
-		Filename:   "./data/watcharr.log",
+		Filename:   path.Join(DataPath, "watcharr.log"),
 		MaxSize:    1, // megabytes
 		MaxBackups: 3,
 		MaxAge:     28, // days


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->
Running Watcharr as a service on NixOS requires changing the data directory path since the nix store (where the binary is located) is read-only.


### Changes made

I'm simply reading the path from an environment variable if set with a fallback to the default `./data` if not. I've also updated the places where the directory was hard-coded to use the `DataPath` var. 
<!-- Describe changes made here. If changes are visual a screenshot could be useful! -->
