### PR TITLE
Posters and Search mobile responsiveness fixes

### DIFF
--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -196,18 +196,6 @@
     cursor: pointer;
   }
 
-  li {
-    @media screen and (max-width: 390px) {
-      flex: 48.5%;
-    }
-    @media screen and (max-width: 355px) {
-      flex: 38.5%;
-    }
-    @media screen and (max-width: 333px) {
-      flex: unset;
-    }
-  }
-
   .container {
     display: flex;
     flex-flow: column;
@@ -216,16 +204,11 @@
     flex: 1 1;
     border-radius: 5px;
     width: 100%;
+    min-width: 170px;
     height: 100%;
     position: relative;
     aspect-ratio: 170000/256367;
-
     transition: transform 150ms ease;
-
-    @media screen and (width < 333px), screen and (width > 390px) {
-      width: 170px;
-      min-height: 256.367px;
-    }
 
     img {
       width: 100%;

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -196,6 +196,18 @@
     cursor: pointer;
   }
 
+  li {
+    @media screen and (max-width: 390px) {
+      flex: 48.5%;
+    }
+    @media screen and (max-width: 355px) {
+      flex: 38.5%;
+    }
+    @media screen and (max-width: 333px) {
+      flex: unset;
+    }
+  }
+
   .container {
     display: flex;
     flex-flow: column;
@@ -203,12 +215,17 @@
     overflow: hidden;
     flex: 1 1;
     border-radius: 5px;
-    width: 170px;
+    width: 100%;
     height: 100%;
-    min-height: 256.367px;
     position: relative;
-    // aspect-ratio: 2/3;
+    aspect-ratio: 170000/256367;
+
     transition: transform 150ms ease;
+
+    @media screen and (width < 333px), screen and (width > 390px) {
+      width: 170px;
+      min-height: 256.367px;
+    }
 
     img {
       width: 100%;

--- a/src/lib/poster/PosterList.svelte
+++ b/src/lib/poster/PosterList.svelte
@@ -41,5 +41,26 @@
       padding: 15px 8px;
       margin: 5px 0;
     }
+
+    &:global(.wrapped li) {
+      @media screen and (max-width: 390px) {
+        flex: 48.5%;
+      }
+      @media screen and (max-width: 355px) {
+        flex: 38.5%;
+      }
+      @media screen and (width <= 335px) {
+        flex: unset;
+      }
+    }
+
+    &:global(.wrapped .container) {
+      min-width: 150px !important;
+
+      @media screen and (width <= 335px), screen and (width > 390px) {
+        width: 170px !important;
+        min-height: 256.367px !important;
+      }
+    }
   }
 </style>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -170,12 +170,6 @@
    * on how big the main search bar is.
    */
   function decideOnNavSplit() {
-    // If window smaller than [...px], always split nav.
-    // (to ensure it doesn't become unsplit when we remove gap below this width).
-    if (window.innerWidth <= 390) {
-      document.body.classList.add("split-nav");
-      return;
-    }
     const bigInput = navEl?.querySelector("input:not(.small)");
     if (bigInput) {
       const b = bigInput.getBoundingClientRect();
@@ -373,15 +367,26 @@
       justify-content: space-between;
       align-items: center;
 
+      /* Slowly decrease the gap to ensure the main search bar doesn't get big enough again and pop back up in the nav. */
+
       @media screen and (max-width: 425px) {
         gap: 15px;
       }
 
       @media screen and (max-width: 380px) {
-        gap: 0;
+        gap: 10px;
+      }
 
-        .btns {
-        }
+      @media screen and (max-width: 375px) {
+        gap: 8px;
+      }
+
+      @media screen and (max-width: 370px) {
+        gap: 5px;
+      }
+
+      @media screen and (max-width: 350px) {
+        gap: 0;
       }
     }
 

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -439,6 +439,9 @@
       width: 100%;
       position: relative;
 
+      // Make the box look a little more centered, inline with the rest of the nav items.
+      margin-bottom: 4px;
+
       :global(svg) {
         display: none;
         position: absolute;

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -440,7 +440,7 @@
       position: relative;
 
       // Make the box look a little more centered, inline with the rest of the nav items.
-      margin-bottom: 4px;
+      margin-bottom: 2px;
 
       :global(svg) {
         display: none;

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -170,6 +170,10 @@
    * on how big the main search bar is.
    */
   function decideOnNavSplit() {
+    if (window.innerWidth <= 260) {
+      document.body.classList.add("split-nav");
+      return;
+    }
     const bigInput = navEl?.querySelector("input:not(.small)");
     if (bigInput) {
       const b = bigInput.getBoundingClientRect();
@@ -367,26 +371,27 @@
       justify-content: space-between;
       align-items: center;
 
-      /* Slowly decrease the gap to ensure the main search bar doesn't get big enough again and pop back up in the nav. */
-
       @media screen and (max-width: 425px) {
         gap: 15px;
       }
 
-      @media screen and (max-width: 380px) {
-        gap: 10px;
-      }
+      /* Slowly decrease the gap to ensure the main search bar doesn't get big enough again and pop back up in the nav. */
+      body.split-nav & {
+        @media screen and (max-width: 380px) {
+          gap: 10px;
+        }
 
-      @media screen and (max-width: 375px) {
-        gap: 8px;
-      }
+        @media screen and (max-width: 375px) {
+          gap: 8px;
+        }
 
-      @media screen and (max-width: 370px) {
-        gap: 5px;
-      }
+        @media screen and (max-width: 370px) {
+          gap: 5px;
+        }
 
-      @media screen and (max-width: 350px) {
-        gap: 0;
+        @media screen and (max-width: 350px) {
+          gap: 0;
+        }
       }
     }
 
@@ -490,6 +495,7 @@
       font-weight: bold;
       text-align: center;
       box-shadow: 4px 4px 0px 0px $text-color;
+      text-overflow: ellipsis;
       transition:
         width 150ms ease,
         box-shadow 150ms ease;

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -170,11 +170,17 @@
    * on how big the main search bar is.
    */
   function decideOnNavSplit() {
+    // If window smaller than [...px], always split nav.
+    // (to ensure it doesn't become unsplit when we remove gap below this width).
+    if (window.innerWidth <= 390) {
+      document.body.classList.add("split-nav");
+      return;
+    }
     const bigInput = navEl?.querySelector("input:not(.small)");
     if (bigInput) {
       const b = bigInput.getBoundingClientRect();
       console.debug("decideOnNavSplit: bigInput bounds:", b);
-      if (b.width <= 80) {
+      if (b.width <= 45) {
         document.body.classList.add("split-nav");
       } else {
         document.body.classList.remove("split-nav");
@@ -217,13 +223,16 @@
       <span class="large">Watcharr</span>
       <span class="small">W</span>
     </a>
-    <input
-      bind:this={mainSearchEl}
-      type="text"
-      placeholder="Search"
-      bind:value={$searchQuery}
-      on:keydown={handleSearch}
-    />
+    <div class="search">
+      <input
+        bind:this={mainSearchEl}
+        type="text"
+        placeholder="Search"
+        bind:value={$searchQuery}
+        on:keydown={handleSearch}
+      />
+      <Icon i="search" wh={19} />
+    </div>
     <div class="btns">
       <!-- Detailed posters only supported on own watched list currently -->
       {#if $page.url?.pathname === "/"}
@@ -364,8 +373,15 @@
       justify-content: space-between;
       align-items: center;
 
+      @media screen and (max-width: 425px) {
+        gap: 15px;
+      }
+
       @media screen and (max-width: 380px) {
         gap: 0;
+
+        .btns {
+        }
       }
     }
 
@@ -409,8 +425,63 @@
       }
     }
 
+    .search {
+      width: 100%;
+      position: relative;
+
+      :global(svg) {
+        display: none;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        pointer-events: none;
+        user-select: none;
+      }
+
+      input:focus-within + :global(svg),
+      input:not(:placeholder-shown) + :global(svg) {
+        display: none;
+      }
+
+      @media screen and (min-width: 666px) {
+        max-width: 250px;
+      }
+
+      @media screen and (max-width: 666px) {
+        & input:not(.small) {
+          width: 100%;
+        }
+
+        &:focus-within + .btns button:not(.face) {
+          display: none;
+        }
+      }
+
+      @media screen and (max-width: 415px) {
+        :global(svg) {
+          display: block;
+        }
+
+        input::placeholder {
+          color: transparent;
+        }
+      }
+    }
+
+    body.split-nav & {
+      .search {
+        opacity: 0;
+        visibility: hidden;
+      }
+
+      input.small {
+        display: block;
+      }
+    }
+
     input {
-      width: 250px;
+      width: 100%;
       font-weight: bold;
       text-align: center;
       box-shadow: 4px 4px 0px 0px $text-color;
@@ -424,30 +495,9 @@
         margin-right: auto;
       }
 
-      body.split-nav & {
-        &:not(.small) {
-          opacity: 0;
-          visibility: hidden;
-        }
-
-        &.small {
-          display: block;
-        }
-      }
-
       &:hover,
       &:focus {
         box-shadow: 2px 2px 0px 0px $text-color;
-      }
-
-      @media screen and (max-width: 666px) {
-        &:not(.small) {
-          width: 100%;
-
-          &:focus + .btns button:not(.face) {
-            display: none;
-          }
-        }
       }
 
       @media screen and (max-width: 290px) {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made
Make posters and nav searchbar more responsive for mobile.

Posters can't get too big or too small, but there is now a region of screen sizes (that hopefully covers most mobiles) where the posters can be dynamically sized, to fit 2 columns of posters.

The nav searchbar now has two stages when it gets too small:

- when the placeholder gets too big: replace with a search icon
  ![image](https://github.com/sbondCo/Watcharr/assets/37304121/71f06148-cbb1-41b9-b38d-5116be839a36)
- when the searchbar is too big: hide and show another searchbar below the nav items
  ![image](https://github.com/sbondCo/Watcharr/assets/37304121/1914f474-2c0c-497c-b66c-8be0ce7feae9)


Closes #385 