### PR TITLE
Support detailed view on search page

### DIFF
--- a/src/lib/WatchedList.svelte
+++ b/src/lib/WatchedList.svelte
@@ -4,10 +4,10 @@
   import Poster from "@/lib/poster/Poster.svelte";
   import PosterList from "@/lib/poster/PosterList.svelte";
   import { activeFilters, activeSort, serverFeatures, userSettings } from "@/store";
-  import type { Watched, WatchedEpisode, WatchedSeason } from "@/types";
+  import type { Watched } from "@/types";
   import GamePoster from "./poster/GamePoster.svelte";
   import { get } from "svelte/store";
-  import { getLatestWatchedInTv, seasonAndEpToReadable } from "./util/helpers";
+  import { getLatestWatchedInTv } from "./util/helpers";
   import { notify } from "./util/notify";
 
   export let list: Watched[];

--- a/src/lib/WatchedList.svelte
+++ b/src/lib/WatchedList.svelte
@@ -7,7 +7,7 @@
   import type { Watched, WatchedEpisode, WatchedSeason } from "@/types";
   import GamePoster from "./poster/GamePoster.svelte";
   import { get } from "svelte/store";
-  import { seasonAndEpToReadable } from "./util/helpers";
+  import { getLatestWatchedInTv, seasonAndEpToReadable } from "./util/helpers";
   import { notify } from "./util/notify";
 
   export let list: Watched[];
@@ -150,82 +150,6 @@
     } catch (err) {
       console.error("filt: Failed to filter/sort current list!", err);
       notify({ text: "Failed to filter/sort list!", type: "error", time: 6000 });
-    }
-  }
-
-  // Get biggest season watching or biggest season watched.
-  // This could probably be simpler but -_-
-  function getLatestWatchedInTv(
-    ws: WatchedSeason[] | undefined,
-    we: WatchedEpisode[] | undefined
-  ): string {
-    if ((!ws || ws.length <= 0) && (!we || we.length <= 0)) {
-      return "";
-    }
-
-    let biggestSeasonWatched = -1;
-    let biggestSeasonWatching = -1;
-    if (ws && ws.length > 0) {
-      for (let i = 0; i < ws.length; i++) {
-        const s = ws[i];
-        if (s.status === "WATCHING") {
-          if (s.seasonNumber > biggestSeasonWatching) {
-            biggestSeasonWatching = s.seasonNumber;
-          }
-        } else if (s.status === "FINISHED") {
-          if (s.seasonNumber > biggestSeasonWatched) {
-            biggestSeasonWatched = s.seasonNumber;
-          }
-        }
-      }
-    }
-    const season = biggestSeasonWatching >= 0 ? biggestSeasonWatching : biggestSeasonWatched;
-
-    // Look for biggest watched/watching episode in season if any.
-    // Does same thing as above.
-    let episode: WatchedEpisode | undefined;
-    if (we && we.length > 0) {
-      let biggestEpisodeWatched: WatchedEpisode | undefined;
-      let biggestEpisodeWatching: WatchedEpisode | undefined;
-      for (let i = 0; i < we.length; i++) {
-        const s = we[i];
-        if (season >= 0 && s.seasonNumber !== season) continue;
-        if (s.status === "WATCHING") {
-          if (!biggestEpisodeWatching) {
-            biggestEpisodeWatching = s;
-          }
-          if (
-            s.episodeNumber > biggestEpisodeWatching.episodeNumber ||
-            s.seasonNumber > biggestEpisodeWatching.seasonNumber
-          ) {
-            biggestEpisodeWatching = s;
-          }
-        } else if (s.status === "FINISHED") {
-          if (!biggestEpisodeWatched) {
-            biggestEpisodeWatched = s;
-          }
-          if (
-            s.episodeNumber > biggestEpisodeWatched.episodeNumber ||
-            s.seasonNumber > biggestEpisodeWatched.seasonNumber
-          ) {
-            biggestEpisodeWatched = s;
-          }
-        }
-      }
-      if (biggestEpisodeWatched || biggestEpisodeWatching) {
-        episode =
-          biggestEpisodeWatching !== undefined ? biggestEpisodeWatching : biggestEpisodeWatched;
-      }
-    }
-
-    if (season >= 0 && episode) {
-      return seasonAndEpToReadable(season, episode.episodeNumber);
-    } else if (season >= 0) {
-      return `Season ${season}`;
-    } else if (episode) {
-      return seasonAndEpToReadable(episode.seasonNumber, episode.episodeNumber);
-    } else {
-      return "";
     }
   }
 </script>

--- a/src/lib/nav/DetailedMenu.svelte
+++ b/src/lib/nav/DetailedMenu.svelte
@@ -2,6 +2,7 @@
   import { wlDetailedView } from "@/store";
   import type { WLDetailedViewOption } from "@/types";
   import { get } from "svelte/store";
+  import { page } from "$app/stores";
 
   function detailClicked(d: WLDetailedViewOption) {
     let dv = get(wlDetailedView);
@@ -16,7 +17,7 @@
   $: dve = $wlDetailedView;
 </script>
 
-<div class="menu">
+<div class={`menu${$page.url?.pathname.startsWith("/search/") ? " on-search-page" : ""}`}>
   <div class="inner">
     <h4 class="norm sm-caps">Shown Details</h4>
     <button
@@ -54,6 +55,10 @@
     &:before {
       left: 3px;
     }
+  }
+
+  div.menu.on-search-page:before {
+    left: 86px;
   }
 
   div.inner {

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -146,7 +146,7 @@
         }}
       />
     {/if}
-    {#if $page.url?.pathname === "/" && extraDetails && dve && dve.length > 0}
+    {#if ($page.url?.pathname === "/" || $page.url?.pathname.startsWith("/search/")) && extraDetails && dve && dve.length > 0}
       <div class="extra-details">
         <!--
           This is one line because svelte leaves whitespace,

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -243,7 +243,7 @@
     </div>
     <div class="btns">
       <!-- Detailed posters only supported on own watched list currently -->
-      {#if $page.url?.pathname === "/"}
+      {#if $page.url?.pathname === "/" || $page.url?.pathname.startsWith("/search/")}
         <button
           class="plain other detailedView"
           on:click={() => {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made
Support detailed view for posters on search page so watched items can be more easily identified with the extra details options enabled.

Moved `getLatestWatchedInTv` to helpers.ts for easy reuse.

Closes #448 