### PR TITLE
Content Pages: Make btns container wrap elements when overflowing

### DIFF
--- a/src/routes/(app)/game/[id]/+page.svelte
+++ b/src/routes/(app)/game/[id]/+page.svelte
@@ -160,32 +160,33 @@
               {/if}
             {/if}
             {#if wListItem}
-              <button
-                class="pin-btn"
-                on:click={() => {
-                  if (wListItem?.pinned) {
-                    contentChanged(undefined, undefined, undefined, false);
-                  } else {
-                    contentChanged(undefined, undefined, undefined, true);
-                  }
-                }}
-                use:tooltip={{
-                  text: `${wListItem?.pinned ? "Unpin from" : "Pin to"} top of list`,
-                  pos: "bot"
-                }}
-              >
-                <Icon i={wListItem?.pinned ? "unpin" : "pin"} wh={19} />
-              </button>
-              <button
-                class="delete-btn"
-                on:click={() =>
-                  wListItem
-                    ? removeWatched(wListItem.id)
-                    : console.error("no wlistItem.. can't delete")}
-                use:tooltip={{ text: "Delete", pos: "bot" }}
-              >
-                <Icon i="trash" wh={19} />
-              </button>
+              <div class="other-side">
+                <button
+                  on:click={() => {
+                    if (wListItem?.pinned) {
+                      contentChanged(undefined, undefined, undefined, false);
+                    } else {
+                      contentChanged(undefined, undefined, undefined, true);
+                    }
+                  }}
+                  use:tooltip={{
+                    text: `${wListItem?.pinned ? "Unpin from" : "Pin to"} top of list`,
+                    pos: "bot"
+                  }}
+                >
+                  <Icon i={wListItem?.pinned ? "unpin" : "pin"} wh={19} />
+                </button>
+                <button
+                  class="delete-btn"
+                  on:click={() =>
+                    wListItem
+                      ? removeWatched(wListItem.id)
+                      : console.error("no wlistItem.. can't delete")}
+                  use:tooltip={{ text: "Delete", pos: "bot" }}
+                >
+                  <Icon i="trash" wh={19} />
+                </button>
+              </div>
             {/if}
           </div>
 
@@ -304,6 +305,7 @@
         .btns {
           display: flex;
           flex-flow: row;
+          flex-wrap: wrap;
           gap: 8px;
           margin-top: auto;
 
@@ -327,8 +329,14 @@
             }
           }
 
-          .pin-btn {
-            margin-left: auto;
+          .other-side {
+            display: flex;
+            flex-flow: row;
+            gap: 8px;
+
+            @media screen and (min-width: 900px) {
+              margin-left: auto;
+            }
           }
 
           .delete-btn {

--- a/src/routes/(app)/movie/[id]/+page.svelte
+++ b/src/routes/(app)/movie/[id]/+page.svelte
@@ -183,32 +183,33 @@
               />
             {/if}
             {#if wListItem}
-              <button
-                class="pin-btn"
-                on:click={() => {
-                  if (wListItem?.pinned) {
-                    contentChanged(undefined, undefined, undefined, false);
-                  } else {
-                    contentChanged(undefined, undefined, undefined, true);
-                  }
-                }}
-                use:tooltip={{
-                  text: `${wListItem?.pinned ? "Unpin from" : "Pin to"} top of list`,
-                  pos: "bot"
-                }}
-              >
-                <Icon i={wListItem?.pinned ? "unpin" : "pin"} wh={19} />
-              </button>
-              <button
-                class="delete-btn"
-                on:click={() =>
-                  wListItem
-                    ? removeWatched(wListItem.id)
-                    : console.error("no wlistItem.. can't delete")}
-                use:tooltip={{ text: "Delete", pos: "bot" }}
-              >
-                <Icon i="trash" wh={19} />
-              </button>
+              <div class="other-side">
+                <button
+                  on:click={() => {
+                    if (wListItem?.pinned) {
+                      contentChanged(undefined, undefined, undefined, false);
+                    } else {
+                      contentChanged(undefined, undefined, undefined, true);
+                    }
+                  }}
+                  use:tooltip={{
+                    text: `${wListItem?.pinned ? "Unpin from" : "Pin to"} top of list`,
+                    pos: "bot"
+                  }}
+                >
+                  <Icon i={wListItem?.pinned ? "unpin" : "pin"} wh={19} />
+                </button>
+                <button
+                  class="delete-btn"
+                  on:click={() =>
+                    wListItem
+                      ? removeWatched(wListItem.id)
+                      : console.error("no wlistItem.. can't delete")}
+                  use:tooltip={{ text: "Delete", pos: "bot" }}
+                >
+                  <Icon i="trash" wh={19} />
+                </button>
+              </div>
             {/if}
           </div>
 
@@ -355,6 +356,7 @@
         .btns {
           display: flex;
           flex-flow: row;
+          flex-wrap: wrap;
           gap: 8px;
           margin-top: auto;
 
@@ -378,8 +380,14 @@
             }
           }
 
-          .pin-btn {
-            margin-left: auto;
+          .other-side {
+            display: flex;
+            flex-flow: row;
+            gap: 8px;
+
+            @media screen and (min-width: 900px) {
+              margin-left: auto;
+            }
           }
 
           .delete-btn {

--- a/src/routes/(app)/tv/[id]/+page.svelte
+++ b/src/routes/(app)/tv/[id]/+page.svelte
@@ -179,32 +179,33 @@
               />
             {/if}
             {#if wListItem}
-              <button
-                class="pin-btn"
-                on:click={() => {
-                  if (wListItem?.pinned) {
-                    contentChanged(undefined, undefined, undefined, false);
-                  } else {
-                    contentChanged(undefined, undefined, undefined, true);
-                  }
-                }}
-                use:tooltip={{
-                  text: `${wListItem?.pinned ? "Unpin from" : "Pin to"} top of list`,
-                  pos: "bot"
-                }}
-              >
-                <Icon i={wListItem?.pinned ? "unpin" : "pin"} wh={19} />
-              </button>
-              <button
-                class="delete-btn"
-                on:click={() =>
-                  wListItem
-                    ? removeWatched(wListItem.id)
-                    : console.error("no wlistItem.. can't delete")}
-                use:tooltip={{ text: "Delete", pos: "bot" }}
-              >
-                <Icon i="trash" wh={19} />
-              </button>
+              <div class="other-side">
+                <button
+                  on:click={() => {
+                    if (wListItem?.pinned) {
+                      contentChanged(undefined, undefined, undefined, false);
+                    } else {
+                      contentChanged(undefined, undefined, undefined, true);
+                    }
+                  }}
+                  use:tooltip={{
+                    text: `${wListItem?.pinned ? "Unpin from" : "Pin to"} top of list`,
+                    pos: "bot"
+                  }}
+                >
+                  <Icon i={wListItem?.pinned ? "unpin" : "pin"} wh={19} />
+                </button>
+                <button
+                  class="delete-btn"
+                  on:click={() =>
+                    wListItem
+                      ? removeWatched(wListItem.id)
+                      : console.error("no wlistItem.. can't delete")}
+                  use:tooltip={{ text: "Delete", pos: "bot" }}
+                >
+                  <Icon i="trash" wh={19} />
+                </button>
+              </div>
             {/if}
           </div>
 
@@ -359,6 +360,7 @@
         .btns {
           display: flex;
           flex-flow: row;
+          flex-wrap: wrap;
           gap: 8px;
           margin-top: auto;
 
@@ -382,8 +384,14 @@
             }
           }
 
-          .pin-btn {
-            margin-left: auto;
+          .other-side {
+            display: flex;
+            flex-flow: row;
+            gap: 8px;
+
+            @media screen and (min-width: 900px) {
+              margin-left: auto;
+            }
           }
 
           .delete-btn {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made
Make buttons on content pages wrap when overflowing.
