### PR TITLE
AutomateShowStatuses setting

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -91,6 +91,8 @@ type UserSettings struct {
 	IncludePreviouslyWatched *bool `gorm:"default:false" json:"includePreviouslyWatched"`
 	// User's country to get correct content streaming providers.
 	Country *string `gorm:"default:'US'" json:"country"`
+	// Does the user want show, season and episode automations enabled.
+	AutomateShowStatuses *bool `gorm:"default:true" json:"automateShowStatuses"`
 }
 
 // Holds third party service auth tokens for users.

--- a/server/user.go
+++ b/server/user.go
@@ -58,6 +58,9 @@ func userUpdate(db *gorm.DB, userId uint, ur UserSettings) (UserSettings, error)
 	if ur.IncludePreviouslyWatched != nil {
 		user.IncludePreviouslyWatched = ur.IncludePreviouslyWatched
 	}
+	if ur.AutomateShowStatuses != nil {
+		user.AutomateShowStatuses = ur.AutomateShowStatuses
+	}
 	if ur.Country != nil {
 		user.Country = ur.Country
 	}
@@ -67,6 +70,7 @@ func userUpdate(db *gorm.DB, userId uint, ur UserSettings) (UserSettings, error)
 		PrivateThoughts:          user.PrivateThoughts,
 		HideSpoilers:             user.HideSpoilers,
 		IncludePreviouslyWatched: user.IncludePreviouslyWatched,
+		AutomateShowStatuses:     user.AutomateShowStatuses,
 		Country:                  user.Country,
 	}, nil
 }
@@ -84,6 +88,7 @@ func userGetSettings(db *gorm.DB, userId uint) (UserSettings, error) {
 		PrivateThoughts:          user.PrivateThoughts,
 		HideSpoilers:             user.HideSpoilers,
 		IncludePreviouslyWatched: user.IncludePreviouslyWatched,
+		AutomateShowStatuses:     user.AutomateShowStatuses,
 		Country:                  user.Country,
 	}, nil
 }

--- a/src/lib/settings/Setting.svelte
+++ b/src/lib/settings/Setting.svelte
@@ -2,16 +2,27 @@
   export let title: string = "";
   export let desc: string = "";
   export let row: boolean = false;
+  export let tag: string | undefined = undefined;
 </script>
 
 <div class={[row ? "row" : "", "setting-ctr"].join(" ")}>
   {#if row}
     <div>
-      <h4 class="norm">{title}</h4>
+      <h4 class="norm">
+        {title}
+        {#if tag}
+          <span class="tag">{tag}</span>
+        {/if}
+      </h4>
       <h5 class="norm">{desc}</h5>
     </div>
   {:else}
-    <h4 class="norm">{title}</h4>
+    <h4 class="norm">
+      {title}
+      {#if tag}
+        <span class="tag">{tag}</span>
+      {/if}
+    </h4>
     <h5 class="norm">{desc}</h5>
   {/if}
 
@@ -21,6 +32,17 @@
 <style lang="scss">
   h4 {
     font-size: 16px;
+    display: flex;
+    flex-flow: row;
+    align-items: center;
+    gap: 5px;
+
+    & > .tag {
+      font-size: 10px;
+      background-color: $accent-color;
+      padding: 3px 5px;
+      border-radius: 5px;
+    }
   }
 
   h5 {

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -27,6 +27,7 @@
   let hideSpoilersDisabled = false;
   let countryDisabled = false;
   let includePreviouslyWatchedDisabled = false;
+  let automateShowStatusesDisabled = false;
   let pwChangeModalOpen = false;
   let getProfilePromise = getProfile();
   let jellyfinSyncModalOpen = false;
@@ -255,6 +256,25 @@
             hideSpoilersDisabled = true;
             updateUserSetting("hideSpoilers", on, () => {
               hideSpoilersDisabled = false;
+            });
+          }}
+        />
+      </Setting>
+
+      <Setting
+        title="Automate Show Statuses"
+        desc="Do you want to automate show statuses (show, season, episode)?"
+        tag="experimental"
+        row
+      >
+        <Checkbox
+          name="automateShowStatusesDisabled"
+          disabled={automateShowStatusesDisabled}
+          value={settings?.automateShowStatuses}
+          toggled={(on) => {
+            automateShowStatusesDisabled = true;
+            updateUserSetting("automateShowStatuses", on, () => {
+              automateShowStatusesDisabled = false;
             });
           }}
         />

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,7 @@ export interface UserSettings {
   hideSpoilers: boolean;
   includePreviouslyWatched: boolean;
   country: string;
+  automateShowStatuses: boolean;
 }
 
 export interface ChangePasswordForm {


### PR DESCRIPTION

<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

`Automate Show Statuses` setting that disables hookEpisodeStatusChanged and will disable future related hooks when they are made.

Defaults to `true`.

Related #380 
