### PR TITLE
Search: Infinite scrolling and serverside content type filters

### DIFF
--- a/server/content.go
+++ b/server/content.go
@@ -256,6 +256,54 @@ func searchContent(query string, pageNum int) (TMDBSearchMultiResponse, error) {
 	return *resp, nil
 }
 
+func searchMovies(query string, pageNum int) (TMDBSearchMoviesResponse, error) {
+	resp := new(TMDBSearchMoviesResponse)
+	if pageNum == 0 {
+		pageNum = 1
+	}
+	err := tmdbRequest("/search/movie", map[string]string{"query": query, "page": strconv.Itoa(pageNum)}, &resp)
+	if err != nil {
+		slog.Error("Failed to complete movie search request!", "error", err.Error())
+		return TMDBSearchMoviesResponse{}, errors.New("failed to complete movie search request")
+	}
+	for i := range resp.Results {
+		resp.Results[i].MediaType = "movie"
+	}
+	return *resp, nil
+}
+
+func searchTv(query string, pageNum int) (TMDBSearchShowsResponse, error) {
+	resp := new(TMDBSearchShowsResponse)
+	if pageNum == 0 {
+		pageNum = 1
+	}
+	err := tmdbRequest("/search/tv", map[string]string{"query": query, "page": strconv.Itoa(pageNum)}, &resp)
+	if err != nil {
+		slog.Error("Failed to complete tv search request!", "error", err.Error())
+		return TMDBSearchShowsResponse{}, errors.New("failed to complete tv search request")
+	}
+	for i := range resp.Results {
+		resp.Results[i].MediaType = "tv"
+	}
+	return *resp, nil
+}
+
+func searchPeople(query string, pageNum int) (TMDBSearchPeopleResponse, error) {
+	resp := new(TMDBSearchPeopleResponse)
+	if pageNum == 0 {
+		pageNum = 1
+	}
+	err := tmdbRequest("/search/person", map[string]string{"query": query, "page": strconv.Itoa(pageNum)}, &resp)
+	if err != nil {
+		slog.Error("Failed to complete people search request!", "error", err.Error())
+		return TMDBSearchPeopleResponse{}, errors.New("failed to complete people search request")
+	}
+	for i := range resp.Results {
+		resp.Results[i].MediaType = "person"
+	}
+	return *resp, nil
+}
+
 func movieDetails(db *gorm.DB, id string, country string, rParams map[string]string) (TMDBMovieDetails, error) {
 	resp := new(TMDBMovieDetails)
 	err := tmdbRequest("/movie/"+id, rParams, &resp)

--- a/server/content.go
+++ b/server/content.go
@@ -243,9 +243,12 @@ func transformProviders(c *interface{}, country string) {
 	}
 }
 
-func searchContent(query string) (TMDBSearchMultiResponse, error) {
+func searchContent(query string, pageNum int) (TMDBSearchMultiResponse, error) {
 	resp := new(TMDBSearchMultiResponse)
-	err := tmdbRequest("/search/multi", map[string]string{"query": query, "page": "1"}, &resp)
+	if pageNum == 0 {
+		pageNum = 1
+	}
+	err := tmdbRequest("/search/multi", map[string]string{"query": query, "page": strconv.Itoa(pageNum)}, &resp)
 	if err != nil {
 		slog.Error("Failed to complete multi search request!", "error", err.Error())
 		return TMDBSearchMultiResponse{}, errors.New("failed to complete multi search request")

--- a/server/import.go
+++ b/server/import.go
@@ -70,7 +70,7 @@ func importContent(db *gorm.DB, userId uint, ar ImportRequest) (ImportResponse, 
 			return successfulImport(db, userId, cr.ID, SHOW, ar)
 		}
 	}
-	sr, err := searchContent(ar.Name)
+	sr, err := searchContent(ar.Name, 1)
 	if err != nil {
 		slog.Error("import: content search failed", "error", err)
 		return ImportResponse{}, errors.New("Content search failed")

--- a/server/routes.go
+++ b/server/routes.go
@@ -102,6 +102,78 @@ func (b *BaseRouter) addContentRoutes() {
 		c.JSON(http.StatusOK, content)
 	}))
 
+	// Search for movies
+	content.GET("/search/movie/:query", cache.CachePage(b.ms, exp, func(c *gin.Context) {
+		if c.Param("query") == "" {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "a query was not provided"})
+			return
+		}
+		pageQ := c.Query("page")
+		pageNum := 1
+		if pageQ != "" {
+			num, err := strconv.Atoi(pageQ)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, ErrorResponse{Error: "query parameter 'page' is not a number"})
+				return
+			}
+			pageNum = num
+		}
+		content, err := searchMovies(c.Param("query"), pageNum)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, content)
+	}))
+
+	// Search for shows
+	content.GET("/search/tv/:query", cache.CachePage(b.ms, exp, func(c *gin.Context) {
+		if c.Param("query") == "" {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "a query was not provided"})
+			return
+		}
+		pageQ := c.Query("page")
+		pageNum := 1
+		if pageQ != "" {
+			num, err := strconv.Atoi(pageQ)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, ErrorResponse{Error: "query parameter 'page' is not a number"})
+				return
+			}
+			pageNum = num
+		}
+		content, err := searchTv(c.Param("query"), pageNum)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, content)
+	}))
+
+	// Search for people
+	content.GET("/search/person/:query", cache.CachePage(b.ms, exp, func(c *gin.Context) {
+		if c.Param("query") == "" {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "a query was not provided"})
+			return
+		}
+		pageQ := c.Query("page")
+		pageNum := 1
+		if pageQ != "" {
+			num, err := strconv.Atoi(pageQ)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, ErrorResponse{Error: "query parameter 'page' is not a number"})
+				return
+			}
+			pageNum = num
+		}
+		content, err := searchPeople(c.Param("query"), pageNum)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, content)
+	}))
+
 	// Get movie details (for movie page)
 	content.GET("/movie/:id", WhereaboutsRequired(), cache.CachePage(b.ms, exp, func(c *gin.Context) {
 		if c.Param("id") == "" {

--- a/server/routes.go
+++ b/server/routes.go
@@ -79,10 +79,9 @@ func (b *BaseRouter) addContentRoutes() {
 	exp := time.Hour * 24
 
 	// Search for content
-	content.GET("/:query", cache.CachePage(b.ms, exp, func(c *gin.Context) {
-		// println(c.Param("query"))
+	content.GET("/search/multi/:query", cache.CachePage(b.ms, exp, func(c *gin.Context) {
 		if c.Param("query") == "" {
-			c.Status(400)
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "a query was not provided"})
 			return
 		}
 		pageQ := c.Query("page")

--- a/server/routes.go
+++ b/server/routes.go
@@ -85,7 +85,17 @@ func (b *BaseRouter) addContentRoutes() {
 			c.Status(400)
 			return
 		}
-		content, err := searchContent(c.Param("query"))
+		pageQ := c.Query("page")
+		pageNum := 1
+		if pageQ != "" {
+			num, err := strconv.Atoi(pageQ)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, ErrorResponse{Error: "query parameter 'page' is not a number"})
+				return
+			}
+			pageNum = num
+		}
+		content, err := searchContent(c.Param("query"), pageNum)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return

--- a/server/tmdb.go
+++ b/server/tmdb.go
@@ -40,6 +40,86 @@ type TMDBSearchMultiResults struct {
 	OriginCountry    []string `json:"origin_country,omitempty"`
 }
 
+type TMDBSearchMoviesResponse struct {
+	Page    int `json:"page"`
+	Results []struct {
+		Adult            bool    `json:"adult"`
+		BackdropPath     string  `json:"backdrop_path"`
+		GenreIds         []int   `json:"genre_ids"`
+		ID               int     `json:"id"`
+		OriginalLanguage string  `json:"original_language"`
+		OriginalTitle    string  `json:"original_title"`
+		Overview         string  `json:"overview"`
+		Popularity       float64 `json:"popularity"`
+		PosterPath       string  `json:"poster_path"`
+		ReleaseDate      string  `json:"release_date"`
+		Title            string  `json:"title"`
+		Video            bool    `json:"video"`
+		VoteAverage      float64 `json:"vote_average"`
+		VoteCount        int     `json:"vote_count"`
+		MediaType        string  `json:"media_type"` // API req doesn't include this, we will add it in our service.
+	} `json:"results"`
+	TotalPages   int `json:"total_pages"`
+	TotalResults int `json:"total_results"`
+}
+
+type TMDBSearchShowsResponse struct {
+	Page    int `json:"page"`
+	Results []struct {
+		Adult            bool     `json:"adult"`
+		BackdropPath     string   `json:"backdrop_path"`
+		GenreIds         []int    `json:"genre_ids"`
+		ID               int      `json:"id"`
+		OriginCountry    []string `json:"origin_country"`
+		OriginalLanguage string   `json:"original_language"`
+		OriginalName     string   `json:"original_name"`
+		Overview         string   `json:"overview"`
+		Popularity       float64  `json:"popularity"`
+		PosterPath       string   `json:"poster_path"`
+		FirstAirDate     string   `json:"first_air_date"`
+		Name             string   `json:"name"`
+		VoteAverage      float64  `json:"vote_average"`
+		VoteCount        int      `json:"vote_count"`
+		MediaType        string   `json:"media_type"` // API req doesn't include this, we will add it in our service.
+	} `json:"results"`
+	TotalPages   int `json:"total_pages"`
+	TotalResults int `json:"total_results"`
+}
+
+type TMDBSearchPeopleResponse struct {
+	Page    int `json:"page"`
+	Results []struct {
+		Adult              bool    `json:"adult"`
+		Gender             int     `json:"gender"`
+		ID                 int     `json:"id"`
+		KnownForDepartment string  `json:"known_for_department"`
+		Name               string  `json:"name"`
+		OriginalName       string  `json:"original_name"`
+		Popularity         float64 `json:"popularity"`
+		ProfilePath        string  `json:"profile_path"`
+		MediaType          string  `json:"media_type"` // API req doesn't include this, we will add it in our service.
+		KnownFor           []struct {
+			Adult            bool    `json:"adult"`
+			BackdropPath     string  `json:"backdrop_path"`
+			ID               int     `json:"id"`
+			Title            string  `json:"title"`
+			OriginalLanguage string  `json:"original_language"`
+			OriginalTitle    string  `json:"original_title"`
+			Overview         string  `json:"overview"`
+			PosterPath       string  `json:"poster_path"`
+			MediaType        string  `json:"media_type"`
+			GenreIds         []int   `json:"genre_ids"`
+			Popularity       float64 `json:"popularity"`
+			ReleaseDate      string  `json:"release_date"`
+			Video            bool    `json:"video"`
+			VoteAverage      float64 `json:"vote_average"`
+			VoteCount        int     `json:"vote_count"`
+		} `json:"known_for"`
+	} `json:"results"`
+	TotalPages   int `json:"total_pages"`
+	TotalResults int `json:"total_results"`
+}
+
 type TMDBContentDetails struct {
 	ID           int    `json:"id"`
 	BackdropPath string `json:"backdrop_path"`

--- a/src/lib/Error.svelte
+++ b/src/lib/Error.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   export let pretty: string;
   export let error: any;
+  export let onRetry: () => void | undefined = undefined!;
 </script>
 
 <div>
@@ -13,6 +14,9 @@
       {/if}
     {:else}
       <p>{JSON.stringify(error)}</p>
+    {/if}
+    {#if onRetry}
+      <button on:click={onRetry}>Try Again</button>
     {/if}
   </div>
 </div>

--- a/src/routes/(app)/search/[query]/+page.svelte
+++ b/src/routes/(app)/search/[query]/+page.svelte
@@ -180,11 +180,20 @@
       console.debug("allSearchResults:", allSearchResults);
       searchResults = allSearchResults;
       curPage++;
+      searchRunning = false;
+      // If results don't fill the page enough to enable scrolling,
+      // the user could be stuck and not be able to get more results
+      // to show, run `infiniteScroll` to load more if we can.
+      // Smol timeout to give ui time to render so end of page calc
+      // can be accurate.
+      setTimeout(() => {
+        infiniteScroll();
+      }, 250);
     } catch (err) {
       console.error("search failed!", err);
       contentSearchErr = err;
+      searchRunning = false;
     }
-    searchRunning = false;
   }
 
   async function doCleanSearch() {

--- a/src/routes/(app)/search/[query]/+page.svelte
+++ b/src/routes/(app)/search/[query]/+page.svelte
@@ -243,6 +243,7 @@
       window.removeEventListener("scroll", infiniteScroll);
       if (data.slug) await search(data.slug);
       window.addEventListener("scroll", infiniteScroll);
+      console.debug(`Page: ${curPage} / ${maxContentPage}`);
     }
   }
 
@@ -278,7 +279,7 @@
   <title>Search Results{data?.slug ? ` for '${data?.slug}'` : ""}</title>
 </svelte:head>
 
-<span style="position: sticky;top: 70px;">{curPage} / {maxContentPage}</span>
+<!-- <span style="position: sticky;top: 70px;">{curPage} / {maxContentPage}</span> -->
 
 <div class="content">
   <div class="inner">

--- a/src/routes/(app)/search/[query]/+page.svelte
+++ b/src/routes/(app)/search/[query]/+page.svelte
@@ -51,7 +51,6 @@
 
   $: searchQ = $searchQuery;
   $: wList = $watchedList;
-  // $: (allSearchResults, activeSearchFilter), filterResults();
 
   async function searchMulti(query: string, page: number) {
     try {
@@ -66,7 +65,6 @@
 
   async function searchMovies(query: string, page: number) {
     try {
-      page = 1;
       const movies = await axios.get<MoviesSearchResponse>(
         `/content/search/movie/${query}?page=${page}`
       );
@@ -81,7 +79,6 @@
 
   async function searchTv(query: string, page: number) {
     try {
-      page = 1;
       const shows = await axios.get<ShowsSearchResponse>(
         `/content/search/tv/${query}?page=${page}`
       );
@@ -96,7 +93,6 @@
 
   async function searchPeople(query: string, page: number) {
     try {
-      page = 1;
       const people = await axios.get<PeopleSearchResponse>(
         `/content/search/person/${query}?page=${page}`
       );
@@ -145,14 +141,25 @@
         // If we have a search filter selected, search for just one specific type of content.
         console.log("Search: A filter is active:", activeSearchFilter);
         if (activeSearchFilter === "movie") {
-          allSearchResults = (await searchMovies(query, curPage + 1)).data.results;
+          const cdata = (await searchMovies(query, curPage + 1)).data;
+          allSearchResults.push(...cdata.results);
+          if (cdata.total_pages) {
+            maxContentPage = cdata.total_pages;
+          }
         } else if (activeSearchFilter === "tv") {
-          allSearchResults = (await searchTv(query, curPage + 1)).data.results;
+          const cdata = (await searchTv(query, curPage + 1)).data;
+          allSearchResults.push(...cdata.results);
+          if (cdata.total_pages) {
+            maxContentPage = cdata.total_pages;
+          }
         } else if (activeSearchFilter === "person") {
-          allSearchResults = (await searchPeople(query, curPage + 1)).data
-            .results as CombinedResult[];
+          const cdata = (await searchPeople(query, curPage + 1)).data;
+          allSearchResults.push(...(cdata.results as CombinedResult[]));
+          if (cdata.total_pages) {
+            maxContentPage = cdata.total_pages;
+          }
         } else if (activeSearchFilter === "game") {
-          allSearchResults = (await searchGames(query, curPage + 1)).data;
+          allSearchResults.push(...(await searchGames(query, curPage + 1)).data);
         } else {
           console.error("Active search filter is invalid:", activeSearchFilter);
         }
@@ -222,13 +229,13 @@
     }
     doCleanSearch();
 
-    // window.addEventListener("scroll", infiniteScroll);
-    // window.addEventListener("resize", infiniteScroll);
+    window.addEventListener("scroll", infiniteScroll);
+    window.addEventListener("resize", infiniteScroll);
 
-    // return () => {
-    //   window.removeEventListener("scroll", infiniteScroll);
-    //   window.removeEventListener("resize", infiniteScroll);
-    // };
+    return () => {
+      window.removeEventListener("scroll", infiniteScroll);
+      window.removeEventListener("resize", infiniteScroll);
+    };
   });
 
   afterNavigate(() => {

--- a/src/routes/(app)/search/[query]/+page.svelte
+++ b/src/routes/(app)/search/[query]/+page.svelte
@@ -14,7 +14,10 @@
     ContentSearchTv,
     GameSearch,
     MediaType,
-    PublicUser
+    MoviesSearchResponse,
+    PeopleSearchResponse,
+    PublicUser,
+    ShowsSearchResponse
   } from "@/types";
   import UsersList from "@/lib/UsersList.svelte";
   import { onDestroy, onMount } from "svelte";
@@ -23,7 +26,7 @@
   import { get } from "svelte/store";
   import { notify } from "@/lib/util/notify.js";
   import Icon from "@/lib/Icon.svelte";
-  import { onNavigate } from "$app/navigation";
+  import { afterNavigate } from "$app/navigation";
 
   type GameWithMediaType = GameSearch & { media_type: "game" };
   type CombinedResult =
@@ -35,44 +38,157 @@
 
   export let data;
 
-  let allSearchResults: CombinedResult[];
-  let searchResults: CombinedResult[];
+  let allSearchResults: CombinedResult[] = [];
+  let searchResults: CombinedResult[] = [];
   let activeSearchFilter: SearchFilterTypes | undefined;
+  let curPage = 0;
+  let maxContentPage = 1;
+  let searchRunning = false;
+  let pageErr: any = "";
+  let contentSearchErr: any;
+
+  const infiniteScrollThreshold = 150;
 
   $: searchQ = $searchQuery;
   $: wList = $watchedList;
-  $: (allSearchResults, activeSearchFilter), filterResults();
+  // $: (allSearchResults, activeSearchFilter), filterResults();
+
+  async function searchMulti(query: string, page: number) {
+    try {
+      return await axios.get<ContentSearch>(`/content/search/multi/${query}?page=${page}`);
+    } catch (err) {
+      console.error("Movies/Tv search failed!", err);
+      notify({ text: "Movie/Tv Search Failed!", type: "error" });
+      contentSearchErr = err;
+      return { data: { results: [], page: 1, total_pages: 1 } };
+    }
+  }
+
+  async function searchMovies(query: string, page: number) {
+    try {
+      page = 1;
+      const movies = await axios.get<MoviesSearchResponse>(
+        `/content/search/movie/${query}?page=${page}`
+      );
+      return movies;
+    } catch (err) {
+      console.error("Movies search failed!", err);
+      notify({ text: "Movie Search Failed!", type: "error" });
+      contentSearchErr = err;
+      return { data: { results: [], page: 1, total_pages: 1 } };
+    }
+  }
+
+  async function searchTv(query: string, page: number) {
+    try {
+      page = 1;
+      const shows = await axios.get<ShowsSearchResponse>(
+        `/content/search/tv/${query}?page=${page}`
+      );
+      return shows;
+    } catch (err) {
+      console.error("Tv search failed!", err);
+      notify({ text: "Tv Search Failed!", type: "error" });
+      contentSearchErr = err;
+      return { data: { results: [], page: 1, total_pages: 1 } };
+    }
+  }
+
+  async function searchPeople(query: string, page: number) {
+    try {
+      page = 1;
+      const people = await axios.get<PeopleSearchResponse>(
+        `/content/search/person/${query}?page=${page}`
+      );
+      return people;
+    } catch (err) {
+      console.error("People search failed!", err);
+      notify({ text: "People Search Failed!", type: "error" });
+      contentSearchErr = err;
+      return { data: { results: [], page: 1, total_pages: 1 } };
+    }
+  }
+
+  async function searchGames(query: string, page: number) {
+    try {
+      const f = get(serverFeatures);
+      if (!f.games) {
+        console.debug("game search is not enabled on this server");
+        return { data: [] };
+      }
+      const games = await axios.get<GameSearch[]>(`/game/search/${query}`);
+      return {
+        data: games.data.map((g) => ({
+          ...g,
+          media_type: "game"
+        })) as GameWithMediaType[]
+      };
+    } catch (err) {
+      console.error("Game search failed!", err);
+      notify({ text: "Game Search Failed!", type: "error" });
+      return { data: [] };
+    }
+  }
 
   async function search(query: string) {
-    const f = get(serverFeatures);
-    if (!f.games) {
-      console.log("Search: Only for movies/tv");
-      allSearchResults = (await axios.get<ContentSearch>(`/content/${query}`)).data.results;
-      searchResults = allSearchResults;
+    if (searchRunning) {
+      console.debug("search: already running");
       return;
     }
-    console.log("Search: For movies/tv and games");
-    // To get around promise.all rejecting both promises when one fails,
-    // catch them separately and return empty object so we can still
-    // display the other media types.
-    const r = await Promise.all([
-      axios.get<ContentSearch>(`/content/${query}`).catch((err) => {
-        console.error("Movies/Tv search failed!", err);
-        notify({ text: "Movie/Tv Search Failed!", type: "error" });
-        return { data: { results: [] } };
-      }),
-      axios.get<GameSearch[]>(`/game/search/${query}`).catch((err) => {
-        console.error("Game search failed!", err);
-        notify({ text: "Game Search Failed!", type: "error" });
-        return { data: [] };
-      })
-    ]);
-    const games: GameWithMediaType[] = r[1].data.map((g) => ({
-      ...g,
-      media_type: "game"
-    }));
-    allSearchResults = new Array<CombinedResult>().concat.apply([], [r[0].data.results, games]);
-    searchResults = allSearchResults;
+    if (curPage === maxContentPage) {
+      console.debug("search: max page reached");
+      return;
+    }
+    searchRunning = true;
+    try {
+      if (activeSearchFilter) {
+        // If we have a search filter selected, search for just one specific type of content.
+        console.log("Search: A filter is active:", activeSearchFilter);
+        if (activeSearchFilter === "movie") {
+          allSearchResults = (await searchMovies(query, curPage + 1)).data.results;
+        } else if (activeSearchFilter === "tv") {
+          allSearchResults = (await searchTv(query, curPage + 1)).data.results;
+        } else if (activeSearchFilter === "person") {
+          allSearchResults = (await searchPeople(query, curPage + 1)).data
+            .results as CombinedResult[];
+        } else if (activeSearchFilter === "game") {
+          allSearchResults = (await searchGames(query, curPage + 1)).data;
+        } else {
+          console.error("Active search filter is invalid:", activeSearchFilter);
+        }
+      } else {
+        // If no search filter is applied, do default multi+game combined search.
+        console.log("Search: No filter is applied.");
+        const r = await Promise.all([
+          searchMulti(query, curPage + 1),
+          searchGames(query, curPage + 1)
+        ]);
+        if (r[0].data.total_pages) {
+          maxContentPage = r[0].data.total_pages;
+        }
+        allSearchResults.push(
+          ...new Array<CombinedResult>().concat.apply([], [r[0].data.results, r[1].data])
+        );
+      }
+      console.debug("allSearchResults:", allSearchResults);
+      searchResults = allSearchResults;
+      curPage++;
+    } catch (err) {
+      console.error("search failed!", err);
+      pageErr = err;
+    }
+    searchRunning = false;
+  }
+
+  async function doCleanSearch() {
+    if (!data.slug) {
+      console.error("doCleanSearch: No query to use.");
+      return;
+    }
+    curPage = 0;
+    allSearchResults = [];
+    searchResults = [];
+    search(data.slug);
   }
 
   async function searchUsers(query: string) {
@@ -82,23 +198,45 @@
   function setActiveSearchFilter(to: SearchFilterTypes) {
     if (activeSearchFilter === to) {
       activeSearchFilter = undefined;
-      return;
+    } else {
+      activeSearchFilter = to;
     }
-    activeSearchFilter = to;
+    doCleanSearch();
   }
 
-  function filterResults() {
-    if (!activeSearchFilter) {
-      searchResults = allSearchResults;
-      return;
+  async function infiniteScroll() {
+    if (
+      window.innerHeight + Math.round(window.scrollY) + infiniteScrollThreshold >=
+      document.body.offsetHeight
+    ) {
+      console.log("reached end");
+      window.removeEventListener("scroll", infiniteScroll);
+      if (data.slug) await search(data.slug);
+      window.addEventListener("scroll", infiniteScroll);
     }
-    searchResults = allSearchResults.filter((s) => s.media_type === activeSearchFilter);
   }
 
   onMount(() => {
     if (!searchQ && data.slug) {
       searchQuery.set(data.slug);
     }
+    doCleanSearch();
+
+    // window.addEventListener("scroll", infiniteScroll);
+    // window.addEventListener("resize", infiniteScroll);
+
+    // return () => {
+    //   window.removeEventListener("scroll", infiniteScroll);
+    //   window.removeEventListener("resize", infiniteScroll);
+    // };
+  });
+
+  afterNavigate(() => {
+    console.log("Query changed, performing new search");
+    if (!searchQ && data.slug) {
+      searchQuery.set(data.slug);
+    }
+    doCleanSearch();
   });
 
   onDestroy(() => {
@@ -109,6 +247,8 @@
 <svelte:head>
   <title>Search Results{data?.slug ? ` for '${data?.slug}'` : ""}</title>
 </svelte:head>
+
+<span style="position: sticky;top: 70px;">{curPage} / {maxContentPage}</span>
 
 <div class="content">
   <div class="inner">
@@ -121,84 +261,72 @@
         <PageError pretty="Failed to load users!" error={err} />
       {/await}
 
-      {#await search(data.slug)}
-        <Spinner />
-      {:then}
-        <div class="results-filters-header">
-          <h2>Results</h2>
-          <div>
-            {#if allSearchResults?.length > 0}
-              {#if allSearchResults.find((s) => s.media_type === "movie") || activeSearchFilter === "movie"}
-                <button
-                  class="plain"
-                  data-active={activeSearchFilter === "movie"}
-                  on:click={() => setActiveSearchFilter("movie")}
-                >
-                  <Icon i="film" wh={20} /> Movies
-                </button>
-              {/if}
-              {#if allSearchResults.find((s) => s.media_type === "tv") || activeSearchFilter === "tv"}
-                <button
-                  class="plain"
-                  data-active={activeSearchFilter === "tv"}
-                  on:click={() => setActiveSearchFilter("tv")}
-                >
-                  <Icon i="tv" wh={20} /> TV Shows
-                </button>
-              {/if}
-              {#if allSearchResults.find((s) => s.media_type === "game") || activeSearchFilter === "game"}
-                <button
-                  class="plain"
-                  data-active={activeSearchFilter === "game"}
-                  on:click={() => setActiveSearchFilter("game")}
-                >
-                  <Icon i="gamepad" wh={20} /> Games
-                </button>
-              {/if}
-              {#if allSearchResults.find((s) => s.media_type === "person") || activeSearchFilter === "person"}
-                <button
-                  class="plain"
-                  data-active={activeSearchFilter === "person"}
-                  on:click={() => setActiveSearchFilter("person")}
-                >
-                  <Icon i="people-nocircle" wh={20} /> People
-                </button>
-              {/if}
-            {/if}
-          </div>
+      <div class={`results-filters-header${searchRunning ? " search-running" : ""}`}>
+        <h2>Results</h2>
+        <div>
+          <button
+            class="plain"
+            data-active={activeSearchFilter === "movie"}
+            on:click={() => setActiveSearchFilter("movie")}
+          >
+            <Icon i="film" wh={20} /> Movies
+          </button>
+          <button
+            class="plain"
+            data-active={activeSearchFilter === "tv"}
+            on:click={() => setActiveSearchFilter("tv")}
+          >
+            <Icon i="tv" wh={20} /> TV Shows
+          </button>
+          <button
+            class="plain"
+            data-active={activeSearchFilter === "game"}
+            on:click={() => setActiveSearchFilter("game")}
+          >
+            <Icon i="gamepad" wh={20} /> Games
+          </button>
+          <button
+            class="plain"
+            data-active={activeSearchFilter === "person"}
+            on:click={() => setActiveSearchFilter("person")}
+          >
+            <Icon i="people-nocircle" wh={20} /> People
+          </button>
         </div>
-        <PosterList>
-          {#if searchResults?.length > 0}
-            {#each searchResults as w (w.id)}
-              {#if w.media_type === "person"}
-                <PersonPoster id={w.id} name={w.name} path={w.profile_path} />
-              {:else if w.media_type === "game"}
-                <GamePoster
-                  media={{
-                    id: w.id,
-                    coverId: w.cover.image_id,
-                    name: w.name,
-                    summary: w.summary,
-                    firstReleaseDate: w.first_release_date
-                  }}
-                  {...getPlayedDependedProps(w.id, wList)}
-                  fluidSize
-                />
-              {:else}
-                <Poster
-                  media={w}
-                  {...getWatchedDependedProps(w.id, w.media_type, wList)}
-                  fluidSize
-                />
-              {/if}
-            {/each}
-          {:else}
-            No Search Results!
-          {/if}
-        </PosterList>
-      {:catch err}
-        <Error pretty="Failed to load results!" error={err} />
-      {/await}
+      </div>
+      <PosterList>
+        {#if searchResults?.length > 0}
+          {#each searchResults as w, i (`${i}-${w.media_type}-${w.id}`)}
+            {#if w.media_type === "person"}
+              <PersonPoster id={w.id} name={w.name} path={w.profile_path} />
+            {:else if w.media_type === "game"}
+              <GamePoster
+                media={{
+                  id: w.id,
+                  coverId: w.cover.image_id,
+                  name: w.name,
+                  summary: w.summary,
+                  firstReleaseDate: w.first_release_date
+                }}
+                {...getPlayedDependedProps(w.id, wList)}
+                fluidSize
+              />
+            {:else}
+              <Poster media={w} {...getWatchedDependedProps(w.id, w.media_type, wList)} fluidSize />
+            {/if}
+          {/each}
+        {:else if !searchRunning}
+          No Search Results!
+        {/if}
+      </PosterList>
+
+      {#if searchRunning}
+        <Spinner />
+      {/if}
+
+      {#if contentSearchErr}
+        <Error pretty="Failed to load results!" error={contentSearchErr} />
+      {/if}
     {:else}
       <h2>No Search Query!</h2>
     {/if}
@@ -256,6 +384,13 @@
       @media screen and (max-width: 500px) {
         width: 100%;
         justify-content: center;
+      }
+    }
+
+    &.search-running {
+      button {
+        opacity: 0.8;
+        pointer-events: none;
       }
     }
   }

--- a/src/routes/(app)/search/[query]/+page.svelte
+++ b/src/routes/(app)/search/[query]/+page.svelte
@@ -106,6 +106,11 @@
 
   async function searchGames(query: string, page: number) {
     try {
+      // Doesn't support pagination, so return if a page higher than 1
+      // is requested.
+      if (page > 1) {
+        return;
+      }
       const f = get(serverFeatures);
       if (!f.games) {
         console.debug("game search is not enabled on this server");
@@ -155,7 +160,12 @@
           // HACK couldn't be bothered to fix this type error
           allSearchResults.push(...(cdata.results as unknown as CombinedResult[]));
         } else if (activeSearchFilter === "game") {
-          allSearchResults.push(...(await searchGames(query, curPage + 1)).data);
+          const gdata = await searchGames(query, curPage + 1);
+          if (gdata) {
+            allSearchResults.push(...gdata.data);
+          } else {
+            console.log("no gdata");
+          }
         } else {
           console.error("Active search filter is invalid:", activeSearchFilter);
         }
@@ -173,7 +183,7 @@
           }
           allSearchResults.push(...r[0].value.data.results);
         }
-        if (r[1].status == "fulfilled") {
+        if (r[1].status == "fulfilled" && r[1].value) {
           allSearchResults.push(...r[1].value.data);
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -688,6 +688,7 @@ export interface TMDBRegions {
   }[];
 }
 
+// ContentSearch* interfaces are for tmdb 'multi' search results.
 export interface ContentSearch {
   page: number;
   results: (ContentSearchMovie | ContentSearchTv | ContentSearchPerson)[];
@@ -738,6 +739,86 @@ export interface ContentSearchPerson {
   known_for?: ContentSearchMovie | ContentSearchTv;
   name?: string;
   popularity?: number;
+}
+
+export interface MoviesSearchResponse {
+  page: number;
+  results: {
+    adult: boolean;
+    backdrop_path: string;
+    genre_ids: number[];
+    id: number;
+    original_language: string;
+    original_title: string;
+    overview: string;
+    popularity: number;
+    poster_path: string;
+    release_date: string;
+    title: string;
+    video: boolean;
+    vote_average: number;
+    vote_count: number;
+    media_type: "movie";
+  }[];
+  total_pages: number;
+  total_results: number;
+}
+
+export interface ShowsSearchResponse {
+  page: number;
+  results: {
+    adult: boolean;
+    backdrop_path: string;
+    genre_ids: number[];
+    id: number;
+    origin_country: string[];
+    original_language: string;
+    original_name: string;
+    overview: string;
+    popularity: number;
+    poster_path: string;
+    first_air_date: string;
+    name: string;
+    vote_average: number;
+    vote_count: number;
+    media_type: "tv";
+  }[];
+  total_pages: number;
+  total_results: number;
+}
+
+export interface PeopleSearchResponse {
+  page: number;
+  results: {
+    adult: boolean;
+    gender: number;
+    id: number;
+    known_for_department: string;
+    name: string;
+    original_name: string;
+    popularity: number;
+    profile_path: string;
+    media_type: "person";
+    known_for: {
+      adult: boolean;
+      backdrop_path: string;
+      id: number;
+      title: string;
+      original_language: string;
+      original_title: string;
+      overview: string;
+      poster_path: string;
+      media_type: string;
+      genre_ids: number[];
+      popularity: number;
+      release_date: string;
+      video: boolean;
+      vote_average: number;
+      vote_count: number;
+    }[];
+  }[];
+  total_pages: number;
+  total_results: number;
 }
 
 export interface GameSearch {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

Search now supports scrolling through multiple pages of results (except for games, I couldn't find anything related to pagination on the igdb docs).

The content type filters now run specific tmdb api requests instead of simply filtering the results displayed in the client.

So basically search is better yippee.

Breaking (for third party tools, if any exist): The content search route for tmdb `multi` endpoint has been moved from `/content/:query` to `/content/search/multi/:query` to accommodate the extra movie, tv and people search endpoints added in this PR. 

Closes #531 
