### PR TITLE
Close all sub menus on nav bar after a navigation

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -208,6 +208,7 @@
 
   afterNavigate(() => {
     decideOnNavSplit();
+    closeAllSubMenus();
   });
 
   onMount(() => {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

Close nav sub menus after a navigation to another page.
