### PR TITLE
Preload last season viewed

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -231,6 +231,7 @@ func (b *BaseRouter) addContentRoutes() {
 	}))
 
 	// Get season details
+	// Supports `watchedId` query parameter for saving the requested season as `LastViewedSeason`.
 	content.GET("/tv/:id/season/:num", func(c *gin.Context) {
 		if c.Param("id") == "" || c.Param("num") == "" {
 			c.Status(400)
@@ -240,6 +241,26 @@ func (b *BaseRouter) addContentRoutes() {
 		if err != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return
+		}
+		// If a `watchedId` is passed, we should update it with this season
+		// number, so the LastViewedSeason field is up to date (this seemed
+		// better than making a new request for just saving this).
+		// We will attach a `watcharr-lastviewedseason-saved` header if
+		// this part succeeds so the client can decide on showing an error.
+		if watchedIdQ := c.Query("watchedId"); watchedIdQ != "" {
+			userId := c.MustGet("userId").(uint)
+			watchedId, err := strconv.ParseUint(watchedIdQ, 10, 64)
+			if err != nil {
+				slog.Error("get season details route: Processing watchedId param failed", "error", err.Error(), "id", watchedIdQ)
+			} else {
+				if seasonNum, err := strconv.ParseInt(c.Param("num"), 10, 64); err == nil {
+					if err = updateWatchedLastViewedSeason(b.db, userId, uint(watchedId), int(seasonNum)); err == nil {
+						c.Header("watcharr-lastviewedseason-saved", "1")
+					}
+				} else {
+					slog.Error("get season details route: Parsing season number as int failed", "error", err.Error(), "season_num", c.Param("num"))
+				}
+			}
 		}
 		c.JSON(http.StatusOK, content)
 	})

--- a/server/routes.go
+++ b/server/routes.go
@@ -261,6 +261,8 @@ func (b *BaseRouter) addContentRoutes() {
 					slog.Error("get season details route: Parsing season number as int failed", "error", err.Error(), "season_num", c.Param("num"))
 				}
 			}
+		} else {
+			slog.Debug("get season details route: No watchedId parameter found.. not doing anything.")
 		}
 		c.JSON(http.StatusOK, content)
 	})

--- a/server/watcharr.go
+++ b/server/watcharr.go
@@ -95,10 +95,23 @@ func main() {
 	gin.DefaultWriter = multiw
 	gine := gin.Default()
 	gine.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{"*"},
-		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowHeaders:     []string{"Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization", "accept", "origin", "Cache-Control", "X-Requested-With"},
-		ExposeHeaders:    []string{"Content-Length"},
+		AllowOrigins: []string{"*"},
+		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowHeaders: []string{
+			"Content-Type",
+			"Content-Length",
+			"Accept-Encoding",
+			"X-CSRF-Token",
+			"Authorization",
+			"accept",
+			"origin",
+			"Cache-Control",
+			"X-Requested-With",
+		},
+		ExposeHeaders: []string{
+			"Content-Length",
+			"watcharr-lastviewedseason-saved",
+		},
 		AllowCredentials: true,
 		MaxAge:           12 * time.Hour,
 	}))

--- a/src/lib/SeasonsList.svelte
+++ b/src/lib/SeasonsList.svelte
@@ -20,7 +20,8 @@
   export let seasons: TMDBShowSeason[];
   export let watchedItem: Watched | undefined;
 
-  let activeSeason = 1;
+  let activeSeason =
+    typeof watchedItem?.lastViewedSeason === "number" ? watchedItem?.lastViewedSeason : 1;
   let seasonDetailsReq: Promise<TMDBSeasonDetails>;
 
   async function sdr(seasonNum: number) {
@@ -33,7 +34,10 @@
       if (watchedItem?.id) {
         // If we sent a watched id, expect a 'watcharr-lastviewedseason-saved' header in the response.
         const hVal = resp.headers["watcharr-lastviewedseason-saved"];
-        if (!hVal) {
+        if (hVal) {
+          watchedItem.lastViewedSeason = seasonNum;
+          watchedList.update((w) => w);
+        } else {
           console.error(
             "SeasonList: sdr: No header in response indicating that the lastviewedseason was saved."
           );

--- a/src/lib/SeasonsListEpisode.svelte
+++ b/src/lib/SeasonsListEpisode.svelte
@@ -17,7 +17,7 @@
   $: settings = $userSettings;
 
   export let ep: TMDBSeasonDetailsEpisode;
-  export let watchedItem: Watched;
+  export let watchedItem: Watched | undefined;
 
   let isHidden = false;
 
@@ -26,6 +26,10 @@
   }
 
   function updateWatchedEpisode(status?: WatchedStatus, rating?: number) {
+    if (!watchedItem) {
+      console.error("SeasonListEpisode: updateWatchedEpisode: No watched item.");
+      return;
+    }
     const nid = notify({ text: `Saving`, type: "loading" });
     axios
       .post<WatchedEpisodeAddResponse>(`/watched/episode`, {
@@ -105,6 +109,10 @@
   }
 
   function handleStatusClick(type: WatchedStatus | "DELETE") {
+    if (!watchedItem) {
+      console.error("SeasonListEpisode: handleStatusClick: No watched item.");
+      return;
+    }
     if (type === "DELETE") {
       const ws = watchedItem.watchedEpisodes?.find(
         (s) => s.seasonNumber === ep.season_number && s.episodeNumber === ep.episode_number

--- a/src/routes/(app)/tv/[id]/+page.svelte
+++ b/src/routes/(app)/tv/[id]/+page.svelte
@@ -292,7 +292,9 @@
       {#if wListItem}
         <Activity wListId={wListItem.id} activity={wListItem.activity} />
       {/if}
-      <SeasonsList tvId={data.tvId} seasons={show.seasons} watchedItem={wListItem} />
+      {#if data?.tvId}
+        <SeasonsList tvId={data.tvId} seasons={show.seasons} watchedItem={wListItem} />
+      {/if}
     </div>
   </div>
 {:else}

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,7 @@ export interface Watched extends dbModel {
   watchedSeasons?: WatchedSeason[];
   watchedEpisodes?: WatchedEpisode[];
   tags?: Tag[];
+  lastViewedSeason?: number;
 }
 
 export interface WatchedAddRequest {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

Added extra logic to the season details request route. If a watchedId is passed, the season number requested will update a `last_viewed_season` property for the watched entry, this value is then used for preloading the last clicked season whenever the specific show is loaded again.

Closes #602 (with this discussed alt solution)
