### PR TITLE
Fix poster focus/accessibility issues and middle clicking

### DIFF
--- a/src/lib/poster/ExtraDetails.svelte
+++ b/src/lib/poster/ExtraDetails.svelte
@@ -103,6 +103,7 @@
     background-color: $poster-extra-detail-bg-color;
     border-radius: 10px;
     transition: opacity 100ms ease-out;
+    pointer-events: none !important;
 
     & > div {
       padding: 8px 3px;

--- a/src/lib/poster/GamePoster.svelte
+++ b/src/lib/poster/GamePoster.svelte
@@ -173,7 +173,7 @@
       id="ilikemoviessueme"
       class="inner"
       role="button"
-      tabindex="0"
+      tabindex="-1"
     >
       <h2>
         {#if typeof onClick === "undefined" && link}

--- a/src/lib/poster/GamePoster.svelte
+++ b/src/lib/poster/GamePoster.svelte
@@ -336,18 +336,18 @@
     }
 
     &:hover,
-    &:focus-within {
+    &:has(:focus-visible) {
       transform: scale(1.3);
       z-index: 99;
     }
 
     &.small:hover,
-    &.small:focus-within {
+    &.small:has(:focus-visible) {
       transform: scale(1.1);
     }
 
     &:hover,
-    &:focus-within,
+    &:has(:focus-visible),
     &:global(.details-shown) {
       img {
         filter: blur(4px) grayscale(80%);

--- a/src/lib/poster/GamePoster.svelte
+++ b/src/lib/poster/GamePoster.svelte
@@ -133,7 +133,12 @@
       posterActive = true;
     }
   }}
-  on:focusout={() => (posterActive = false)}
+  on:focusout={() => {
+    if (!isTouch()) {
+      // Only on !isTouch (to match focusin) to avoid breaking a tap and hold on link on mobile.
+      posterActive = false;
+    }
+  }}
   on:mouseleave={() => (posterActive = false)}
   on:click={() => (posterActive = true)}
   on:keypress={() => console.log("on kpress")}

--- a/src/lib/poster/GamePoster.svelte
+++ b/src/lib/poster/GamePoster.svelte
@@ -141,6 +141,11 @@
   }}
   on:mouseleave={() => (posterActive = false)}
   on:click={() => (posterActive = true)}
+  on:keyup={(e) => {
+    if (e.key === "Tab") {
+      e.currentTarget.scrollIntoView({ block: "center" });
+    }
+  }}
   on:keypress={() => console.log("on kpress")}
   class={`${posterActive ? "active " : ""}${pinned ? "pinned " : ""}`}
 >
@@ -171,9 +176,11 @@
       <ExtraDetails details={extraDetails} {status} {rating} />
     {/if}
     <div
-      on:click={() => {
+      on:click={(e) => {
         if (typeof onClick !== "undefined") {
           onClick();
+          // Prevent the link inside this div from being clicked in this case.
+          e.preventDefault();
           return;
         }
         if (posterActive && link) goto(link);
@@ -184,19 +191,15 @@
       role="button"
       tabindex="-1"
     >
-      <h2>
-        {#if typeof onClick === "undefined" && link}
-          <a data-sveltekit-preload-data="tap" href={link}>
-            {title}
-          </a>
-        {:else}
+      <a data-sveltekit-preload-data="tap" href={link}>
+        <h2>
           {title}
-        {/if}
-        {#if year}
-          <time>{year}</time>
-        {/if}
-      </h2>
-      <span>{media.summary}</span>
+          {#if year}
+            <time>{year}</time>
+          {/if}
+        </h2>
+        <span>{media.summary}</span>
+      </a>
 
       {#if !hideButtons}
         <div class="buttons">
@@ -215,6 +218,15 @@
 
   li.pinned:not(.active) .container {
     outline: 3px solid gold;
+  }
+
+  li {
+    &:not(.active) {
+      .container .inner,
+      .container .inner .buttons {
+        pointer-events: none !important;
+      }
+    }
   }
 
   .container {
@@ -299,6 +311,10 @@
       background-color: transparent;
       transition: opacity 150ms cubic-bezier(0.19, 1, 0.22, 1);
 
+      & > a {
+        height: 100%;
+      }
+
       h2 {
         font-family:
           sans-serif,
@@ -344,19 +360,16 @@
       font-size: 11px;
     }
 
-    &:hover,
-    &:has(:focus-visible) {
+    .active & {
       transform: scale(1.3);
       z-index: 99;
     }
 
-    &.small:hover,
-    &.small:has(:focus-visible) {
+    .active &.small {
       transform: scale(1.1);
     }
 
-    &:hover,
-    &:has(:focus-visible),
+    .active &,
     &:global(.details-shown) {
       img {
         filter: blur(4px) grayscale(80%);

--- a/src/lib/poster/GamePoster.svelte
+++ b/src/lib/poster/GamePoster.svelte
@@ -129,7 +129,11 @@
   }}
   on:focusin={(e) => {
     if (!posterActive) calculateTransformOrigin(e);
+    if (!isTouch()) {
+      posterActive = true;
+    }
   }}
+  on:focusout={() => (posterActive = false)}
   on:mouseleave={() => (posterActive = false)}
   on:click={() => (posterActive = true)}
   on:keypress={() => console.log("on kpress")}

--- a/src/lib/poster/GamePoster.svelte
+++ b/src/lib/poster/GamePoster.svelte
@@ -139,7 +139,23 @@
       posterActive = false;
     }
   }}
-  on:mouseleave={() => (posterActive = false)}
+  on:mouseleave={() => {
+    posterActive = false;
+    const ae = document.activeElement;
+    if (
+      ae &&
+      ae instanceof HTMLElement &&
+      (ae.parentElement?.id === "ilikemoviessueme" ||
+        ae.parentElement?.parentElement?.id === "ilikemoviessueme")
+    ) {
+      // Stops the poster being re-focused after the browser window
+      // loses focus, then regains it (ex: you middle click the poster,
+      // go to the opened tab (or lose browser window focus, then when
+      // you come back the poster is sent `focusin` and stuck activated
+      // until mouseleave again).
+      ae.blur();
+    }
+  }}
   on:click={() => (posterActive = true)}
   on:keyup={(e) => {
     if (e.key === "Tab") {

--- a/src/lib/poster/PersonPoster.svelte
+++ b/src/lib/poster/PersonPoster.svelte
@@ -143,7 +143,7 @@
 
     &:not(.no-zoom) {
       &:hover,
-      &:focus-within {
+      &:has(:focus-visible) {
         transform: scale(1.3);
         z-index: 99;
       }
@@ -151,13 +151,13 @@
 
     &:not(:not(.no-zoom)) {
       &:hover,
-      &:focus-within {
+      &:has(:focus-visible) {
         outline: 3px solid $text-color;
       }
     }
 
     &:hover,
-    &:focus-within,
+    &:has(:focus-visible),
     &:global(.details-shown) {
       .inner {
         color: white;

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -113,6 +113,11 @@
   }}
   on:mouseleave={() => (posterActive = false)}
   on:click={() => (posterActive = true)}
+  on:keyup={(e) => {
+    if (e.key === "Tab") {
+      e.currentTarget.scrollIntoView({ block: "center" });
+    }
+  }}
   on:keypress={() => console.log("on kpress")}
   class={`${posterActive ? "active " : ""}${pinned ? "pinned " : ""}`}
 >
@@ -139,9 +144,11 @@
       <ExtraDetails details={extraDetails} {status} {rating} />
     {/if}
     <div
-      on:click={() => {
+      on:click={(e) => {
         if (typeof onClick !== "undefined") {
           onClick();
+          // Prevent the link inside this div from being clicked in this case.
+          e.preventDefault();
           return;
         }
         if (posterActive && link) goto(link);
@@ -152,19 +159,15 @@
       role="button"
       tabindex="-1"
     >
-      <h2>
-        {#if typeof onClick === "undefined" && link}
-          <a data-sveltekit-preload-data="tap" href={link}>
-            {title}
-          </a>
-        {:else}
+      <a data-sveltekit-preload-data="tap" href={link}>
+        <h2>
           {title}
-        {/if}
-        {#if year}
-          <time>{year}</time>
-        {/if}
-      </h2>
-      <span>{media.overview}</span>
+          {#if year}
+            <time>{year}</time>
+          {/if}
+        </h2>
+        <span>{media.overview}</span>
+      </a>
 
       {#if !hideButtons}
         <div class="buttons">
@@ -183,6 +186,15 @@
 
   li.pinned:not(.active) .container {
     outline: 3px solid gold;
+  }
+
+  li {
+    &:not(.active) {
+      .container .inner,
+      .container .inner .buttons {
+        pointer-events: none !important;
+      }
+    }
   }
 
   .container {
@@ -247,6 +259,10 @@
       background-color: transparent;
       transition: opacity 150ms cubic-bezier(0.19, 1, 0.22, 1);
 
+      & > a {
+        height: 100%;
+      }
+
       h2 {
         font-family:
           sans-serif,
@@ -292,19 +308,16 @@
       font-size: 11px;
     }
 
-    &:hover,
-    &:has(:focus-visible) {
+    .active & {
       transform: scale(1.3);
       z-index: 99;
     }
 
-    &.small:hover,
-    &.small:has(:focus-visible) {
+    .active &.small {
       transform: scale(1.1);
     }
 
-    &:hover,
-    &:has(:focus-visible),
+    .active &,
     &:global(.details-shown) {
       img {
         filter: blur(4px) grayscale(80%);

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -105,7 +105,12 @@
       posterActive = true;
     }
   }}
-  on:focusout={() => (posterActive = false)}
+  on:focusout={() => {
+    if (!isTouch()) {
+      // Only on !isTouch (to match focusin) to avoid breaking a tap and hold on link on mobile.
+      posterActive = false;
+    }
+  }}
   on:mouseleave={() => (posterActive = false)}
   on:click={() => (posterActive = true)}
   on:keypress={() => console.log("on kpress")}

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -141,7 +141,7 @@
       id="ilikemoviessueme"
       class="inner"
       role="button"
-      tabindex="0"
+      tabindex="-1"
     >
       <h2>
         {#if typeof onClick === "undefined" && link}

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -111,7 +111,23 @@
       posterActive = false;
     }
   }}
-  on:mouseleave={() => (posterActive = false)}
+  on:mouseleave={() => {
+    posterActive = false;
+    const ae = document.activeElement;
+    if (
+      ae &&
+      ae instanceof HTMLElement &&
+      (ae.parentElement?.id === "ilikemoviessueme" ||
+        ae.parentElement?.parentElement?.id === "ilikemoviessueme")
+    ) {
+      // Stops the poster being re-focused after the browser window
+      // loses focus, then regains it (ex: you middle click the poster,
+      // go to the opened tab (or lose browser window focus, then when
+      // you come back the poster is sent `focusin` and stuck activated
+      // until mouseleave again).
+      ae.blur();
+    }
+  }}
   on:click={() => (posterActive = true)}
   on:keyup={(e) => {
     if (e.key === "Tab") {

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -101,7 +101,11 @@
   }}
   on:focusin={(e) => {
     if (!posterActive) calculateTransformOrigin(e);
+    if (!isTouch()) {
+      posterActive = true;
+    }
   }}
+  on:focusout={() => (posterActive = false)}
   on:mouseleave={() => (posterActive = false)}
   on:click={() => (posterActive = true)}
   on:keypress={() => console.log("on kpress")}

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -284,18 +284,18 @@
     }
 
     &:hover,
-    &:focus-within {
+    &:has(:focus-visible) {
       transform: scale(1.3);
       z-index: 99;
     }
 
     &.small:hover,
-    &.small:focus-within {
+    &.small:has(:focus-visible) {
       transform: scale(1.1);
     }
 
     &:hover,
-    &:focus-within,
+    &:has(:focus-visible),
     &:global(.details-shown) {
       img {
         filter: blur(4px) grayscale(80%);

--- a/src/lib/poster/PosterRating.svelte
+++ b/src/lib/poster/PosterRating.svelte
@@ -67,60 +67,65 @@
       {/if}
     </span>
 
-    {#if ratingsShown}
-      <div class={["small-scrollbar", direction, isUsingThumbs ? "is-using-thumbs" : ""].join(" ")}>
-        {#if isUsingThumbs}
-          <button
-            on:click={() => handleStarClick(1)}
-            class="plain{rating && rating > 0 && rating < 5 ? ' active' : ''}"
-            style="display: flex; justify-content: center;"
+    <div
+      class={[
+        ratingsShown ? "shown" : "",
+        "small-scrollbar",
+        direction,
+        isUsingThumbs ? "is-using-thumbs" : ""
+      ].join(" ")}
+    >
+      {#if isUsingThumbs}
+        <button
+          on:click={() => handleStarClick(1)}
+          class="plain{rating && rating > 0 && rating < 5 ? ' active' : ''}"
+          style="display: flex; justify-content: center;"
+        >
+          <i style="display: flex; width: 35px;"><Icon i="thumb-down" /></i>
+        </button>
+        <button
+          on:click={() => handleStarClick(5)}
+          class="plain{rating && rating > 4 && rating < 9 ? ' active' : ''}"
+          style="display: flex; justify-content: center;"
+        >
+          <span
+            style="display: flex; transform: translate(0px, -2px); font-size: 40px; height: 40px; font-family: 'Shrikhand';"
           >
-            <i style="display: flex; width: 35px;"><Icon i="thumb-down" /></i>
-          </button>
+            -
+          </span>
+        </button>
+        <button
+          on:click={() => handleStarClick(9)}
+          class="plain{rating && rating > 8 ? ' active' : ''}"
+          style="display: flex; justify-content: center;"
+        >
+          <i style="display: flex; width: 35px;"><Icon i="thumb-up" /></i>
+        </button>
+      {:else}
+        {@const stars =
+          settings?.ratingSystem == RatingSystem.OutOf5
+            ? [5, 4, 3, 2, 1]
+            : [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]}
+        {#each stars as v}
           <button
-            on:click={() => handleStarClick(5)}
-            class="plain{rating && rating > 4 && rating < 9 ? ' active' : ''}"
-            style="display: flex; justify-content: center;"
+            class="plain{rating === v ? ' active' : ''}"
+            on:click={(ev) => {
+              ev.stopPropagation();
+              handleStarClick(settings?.ratingSystem === RatingSystem.OutOf5 ? v * 2 : v);
+              ratingsShown = false;
+            }}
           >
-            <span
-              style="display: flex; transform: translate(0px, -2px); font-size: 40px; height: 40px; font-family: 'Shrikhand';"
-            >
-              -
-            </span>
+            {#if settings?.ratingSystem === RatingSystem.OutOf100}
+              {v * 10}
+            {:else if settings?.ratingSystem === RatingSystem.OutOf5}
+              {v}
+            {:else}
+              {v}
+            {/if}
           </button>
-          <button
-            on:click={() => handleStarClick(9)}
-            class="plain{rating && rating > 8 ? ' active' : ''}"
-            style="display: flex; justify-content: center;"
-          >
-            <i style="display: flex; width: 35px;"><Icon i="thumb-up" /></i>
-          </button>
-        {:else}
-          {@const stars =
-            settings?.ratingSystem == RatingSystem.OutOf5
-              ? [5, 4, 3, 2, 1]
-              : [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]}
-          {#each stars as v}
-            <button
-              class="plain{rating === v ? ' active' : ''}"
-              on:click={(ev) => {
-                ev.stopPropagation();
-                handleStarClick(settings?.ratingSystem === RatingSystem.OutOf5 ? v * 2 : v);
-                ratingsShown = false;
-              }}
-            >
-              {#if settings?.ratingSystem === RatingSystem.OutOf100}
-                {v * 10}
-              {:else if settings?.ratingSystem === RatingSystem.OutOf5}
-                {v}
-              {:else}
-                {v}
-              {/if}
-            </button>
-          {/each}
-        {/if}
-      </div>
-    {/if}
+        {/each}
+      {/if}
+    </div>
   {:else if rating}
     <span class="rating-text">
       {rating}
@@ -222,6 +227,10 @@
       scrollbar-width: thin;
       z-index: 40;
       box-shadow: 0px 0px 1px #000;
+
+      &:not(.shown) {
+        display: none;
+      }
 
       &.bot {
         top: calc(100% + 2px);

--- a/src/lib/poster/PosterRating.svelte
+++ b/src/lib/poster/PosterRating.svelte
@@ -35,7 +35,6 @@
   }}
   on:mouseleave={(ev) => {
     ratingsShown = false;
-    ev.currentTarget.blur();
   }}
   use:tooltip={{ text: btnTooltip, pos: "top", condition: !!btnTooltip && !ratingsShown }}
 >

--- a/src/lib/poster/PosterStatus.svelte
+++ b/src/lib/poster/PosterStatus.svelte
@@ -33,30 +33,35 @@
   {:else}
     <span class={["no-icon", small ? "small" : ""].join(" ")}>+</span>
   {/if}
-  {#if statusesShown}
-    <div class={["small-scrollbar", status ? "has-status" : "", direction].join(" ")}>
-      {#each Object.entries(watchedStatuses) as [statusName, icon]}
-        <button
-          class="plain{status && status !== statusName ? ' not-active' : ''}"
-          on:click={() => handleStatusClick(statusName)}
-          use:tooltip={{
-            text: toUnderstandableStatus(statusName, isForGame)
-          }}
-        >
-          <Icon i={icon} />
-        </button>
-      {/each}
-      {#if status}
-        <button
-          class="plain not-active"
-          on:click={() => handleStatusClick("DELETE")}
-          use:tooltip={{ text: "Delete" }}
-        >
-          <Icon i="trash" />
-        </button>
-      {/if}
-    </div>
-  {/if}
+  <div
+    class={[
+      statusesShown ? "shown" : "",
+      "small-scrollbar",
+      status ? "has-status" : "",
+      direction
+    ].join(" ")}
+  >
+    {#each Object.entries(watchedStatuses) as [statusName, icon]}
+      <button
+        class="plain{status && status !== statusName ? ' not-active' : ''}"
+        on:click={() => handleStatusClick(statusName)}
+        use:tooltip={{
+          text: toUnderstandableStatus(statusName, isForGame)
+        }}
+      >
+        <Icon i={icon} />
+      </button>
+    {/each}
+    {#if status}
+      <button
+        class="plain not-active"
+        on:click={() => handleStatusClick("DELETE")}
+        use:tooltip={{ text: "Delete" }}
+      >
+        <Icon i="trash" />
+      </button>
+    {/if}
+  </div>
 </button>
 
 <style lang="scss">
@@ -110,6 +115,10 @@
       scrollbar-width: thin;
       z-index: 40;
       box-shadow: 0px 0px 1px #000;
+
+      &:not(.shown) {
+        display: none;
+      }
 
       &.bot {
         top: calc(100% + 2px);

--- a/src/lib/poster/PosterStatus.svelte
+++ b/src/lib/poster/PosterStatus.svelte
@@ -25,7 +25,6 @@
   }}
   on:mouseleave={(ev) => {
     statusesShown = false;
-    ev.currentTarget.blur();
   }}
   use:tooltip={{ text: btnTooltip, pos: "top", condition: !!btnTooltip && !statusesShown }}
 >


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made
- Poster can now be middle clicked anywhere in middle (except rating/status buttons) to open in new tab (used to be only title that had the link).
- Fixed posters being refocused after tab regains focus (eg, middle click poster, go to new tab, come back, poster is reactivated for no reason).
- Fixed can't unfocus a poster after giving it a rating/status through poster quick actions (mobile).
- Improved keyboard accessibility for tabbing through posters:
    - One less irrelevant element per poster to tab through
    - Tabbing to anywhere in a poster will now always center the whole poster into view
    -  Hide extraDetails when poster activated by tabbing to it.

Fixes #620 