### PR TITLE
Fix poster summary overflowing

### DIFF
--- a/src/lib/poster/GamePoster.svelte
+++ b/src/lib/poster/GamePoster.svelte
@@ -207,7 +207,7 @@
       role="button"
       tabindex="-1"
     >
-      <a data-sveltekit-preload-data="tap" href={link}>
+      <a data-sveltekit-preload-data="tap" href={link} class="small-scrollbar">
         <h2>
           {title}
           {#if year}
@@ -329,6 +329,7 @@
 
       & > a {
         height: 100%;
+        overflow: auto;
       }
 
       h2 {

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -175,7 +175,7 @@
       role="button"
       tabindex="-1"
     >
-      <a data-sveltekit-preload-data="tap" href={link}>
+      <a data-sveltekit-preload-data="tap" href={link} class="small-scrollbar">
         <h2>
           {title}
           {#if year}
@@ -277,6 +277,7 @@
 
       & > a {
         height: 100%;
+        overflow: auto;
       }
 
       h2 {

--- a/src/norm.scss
+++ b/src/norm.scss
@@ -253,18 +253,27 @@
   }
 
   .small-scrollbar {
-    &::-webkit-scrollbar {
-      width: 4.5px;
-    }
+    @supports selector(::-webkit-scrollbar) {
+      &::-webkit-scrollbar {
+        width: 4.5px;
+      }
 
-    &::-webkit-scrollbar-track {
-      background: transparent;
-    }
+      &::-webkit-scrollbar-track {
+        background: transparent;
+      }
 
-    &::-webkit-scrollbar-thumb {
-      background-color: rgba(155, 155, 155, 0.5);
-      border-radius: 20px;
-      border: transparent;
+      &::-webkit-scrollbar-thumb {
+        background-color: rgba(155, 155, 155, 0.5);
+        border-radius: 20px;
+        border: transparent;
+      }
+
+      // The scrollbar-width property will always override
+      // -webkit-scrollbar, but since the scrollbars in
+      // chromium look ugly af, we will try to unset scrollbar-width
+      // in these cases and use our manual styling instead to try
+      // mimicking beatiful firefox.
+      scrollbar-width: auto !important;
     }
   }
 }


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

- Poster title/summary section now shows scrollbar when it is too long, instead of pushing rating/status buttons down.
- Fix the `small-scrollbar` style. Now working properly for the rating/status lists in poster.
