### PR TITLE
Ryot fix dates import

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: ""
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 <!-- It's harder to track bugs when multiple are reported in one issue. If you have more than one (unrelated) bugs to report, please make one issue per bug. -->
@@ -14,6 +13,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -26,9 +26,10 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Platform (please complete the following information):**
- - OS: [e.g. Linux, Windows, Android, iOS]
- - Browser (latest version): [e.g. chrome, safari, firefox]
- - Watcharr Version: [e.g. v1.45.0]
+
+- OS: [e.g. Linux, Windows, Android, iOS]
+- Browser (latest version): [e.g. chrome, safari, firefox]
+- Watcharr Version: [e.g. v1.45.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/02-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02-feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: ""
 labels: enhancement
-assignees: ''
-
+assignees: ""
 ---
 
 <!-- Feature requests can be hard to track when two or more unrelated ideas are included in one issue. Please make a new issue for each idea (make as many as you need to). -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,10 +1,9 @@
 ---
 name: Documentation
 about: Help us with our documentation. Is something important missing?
-title: ''
+title: ""
 labels: documentation
 assignees: IRHM
-
 ---
 
 <!-- Did you know: You can click `Edit this page` at the bottom of any page on the docs to propose exact changes? If this doesn't apply to you, continue below and fill out the issue. -->

--- a/src/routes/(app)/import/+page.svelte
+++ b/src/routes/(app)/import/+page.svelte
@@ -478,26 +478,30 @@
               : [],
 
           // Episode ratings are on a separate field: "reviews"
-          watchedEpisodes: v.seen_history?.map((episode: any) => ({
-            status: episode.progress === "100" ? "FINISHED" : "WATCHING",
+          watchedEpisodes:
+            v.lot === "show"
+              ? v.seen_history?.map((episode: any) => ({
+                  status: episode.progress === "100" ? "FINISHED" : "WATCHING",
 
-            // Linear :( search the reviews for a match
-            rating:
-              validifyRating(
-                Number(
-                  (
-                    v.reviews?.find(
-                      (review: any) =>
-                        review.show_season_number === episode.show_season_number &&
-                        review.show_episode_number === episode.show_episode_number
-                    ) || {}
-                  )?.rating
-                )
-              ) || null,
+                  // Linear :( search the reviews for a match
+                  rating:
+                    validifyRating(
+                      Number(
+                        (
+                          v.reviews?.find(
+                            (review: any) =>
+                              review.show_season_number === episode.show_season_number &&
+                              review.show_episode_number === episode.show_episode_number
+                          ) || {}
+                        )?.rating
+                      )
+                    ) || null,
 
-            seasonNumber: episode.show_season_number,
-            episodeNumber: episode.show_episode_number
-          }))
+                  seasonNumber: episode.show_season_number,
+                  episodeNumber: episode.show_episode_number,
+                  createdAt: new Date(episode.ended_on)
+                }))
+              : undefined
         };
         toImport.push(t);
       }

--- a/src/routes/(app)/import/+page.svelte
+++ b/src/routes/(app)/import/+page.svelte
@@ -499,7 +499,7 @@
 
                   seasonNumber: episode.show_season_number,
                   episodeNumber: episode.show_episode_number,
-                  createdAt: new Date(episode.ended_on)
+                  createdAt: episode.ended_on ? new Date(episode.ended_on) : undefined
                 }))
               : undefined
         };

--- a/src/routes/(app)/import/process/+page.svelte
+++ b/src/routes/(app)/import/process/+page.svelte
@@ -339,7 +339,11 @@
       parsedImportedList.set(rList);
       goto("/import/some-failed");
     } else {
-      notify({ type: "success", text: "All content successfully imported!" });
+      notify({
+        type: "success",
+        text: "All content successfully imported! Try refreshing if you are missing data.",
+        time: 15000
+      });
       goto("/");
     }
   }


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

- Fix ryot import not importing date for watchedEpisodes.
- Add note to 'successful import' notification that refreshing the tab may fetch any missing data.

Fixes #663