### PR TITLE
Search by external id

### DIFF
--- a/server/content.go
+++ b/server/content.go
@@ -323,6 +323,9 @@ func searchByExternalId(id string, source string) (TMDBSearchMultiResponse, erro
 	return TMDBSearchMultiResponse{TMDBSearchResponse: TMDBSearchResponse[TMDBSearchMultiResults]{
 		Results:      comb,
 		TotalResults: len(comb),
+		// Just providing these so we don't break frontend pagination logic.
+		TotalPages: 1,
+		Page:       1,
 	}}, nil
 }
 

--- a/server/content.go
+++ b/server/content.go
@@ -304,6 +304,28 @@ func searchPeople(query string, pageNum int) (TMDBSearchPeopleResponse, error) {
 	return *resp, nil
 }
 
+// Search for content by an external id (imdb, etc).
+// Defaults to imdb if no source if provided (probably most common).
+func searchByExternalId(id string, source string) (TMDBSearchMultiResponse, error) {
+	resp := new(TMDBFindByExternalIdResponse)
+	if source == "" {
+		source = "imdb"
+	}
+	err := tmdbRequest("/find/"+id, map[string]string{"external_source": source + "_id"}, &resp)
+	if err != nil {
+		slog.Error("Failed to complete find/external_id request!", "error", err.Error())
+		return TMDBSearchMultiResponse{}, errors.New("failed to complete find/external_id request")
+	}
+	comb := []TMDBSearchMultiResults{}
+	comb = append(comb, resp.MovieResults...)
+	comb = append(comb, resp.TvResults...)
+	comb = append(comb, resp.PersonResults...)
+	return TMDBSearchMultiResponse{TMDBSearchResponse: TMDBSearchResponse[TMDBSearchMultiResults]{
+		Results:      comb,
+		TotalResults: len(comb),
+	}}, nil
+}
+
 func movieDetails(db *gorm.DB, id string, country string, rParams map[string]string) (TMDBMovieDetails, error) {
 	resp := new(TMDBMovieDetails)
 	err := tmdbRequest("/movie/"+id, rParams, &resp)

--- a/server/routes.go
+++ b/server/routes.go
@@ -174,6 +174,20 @@ func (b *BaseRouter) addContentRoutes() {
 		c.JSON(http.StatusOK, content)
 	}))
 
+	// Search for content with external id
+	content.GET("/search/ext/:id/:source", cache.CachePage(b.ms, exp, func(c *gin.Context) {
+		if c.Param("id") == "" {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "an id was not provided"})
+			return
+		}
+		content, err := searchByExternalId(c.Param("id"), c.Param("source"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, content)
+	}))
+
 	// Get movie details (for movie page)
 	content.GET("/movie/:id", WhereaboutsRequired(), cache.CachePage(b.ms, exp, func(c *gin.Context) {
 		if c.Param("id") == "" {

--- a/server/tmdb.go
+++ b/server/tmdb.go
@@ -10,11 +10,11 @@ import (
 	"time"
 )
 
-type TMDBSearchMultiResponse struct {
-	Page         int                      `json:"page"`
-	Results      []TMDBSearchMultiResults `json:"results"`
-	TotalPages   int                      `json:"total_pages"`
-	TotalResults int                      `json:"total_results"`
+type TMDBSearchResponse[R any] struct {
+	Page         int `json:"page"`
+	Results      []R `json:"results"`
+	TotalPages   int `json:"total_pages"`
+	TotalResults int `json:"total_results"`
 }
 
 type TMDBSearchMultiResults struct {
@@ -40,84 +40,98 @@ type TMDBSearchMultiResults struct {
 	OriginCountry    []string `json:"origin_country,omitempty"`
 }
 
+type TMDBSearchMultiResponse struct {
+	TMDBSearchResponse[TMDBSearchMultiResults]
+}
+
+type TMDBSearchMovieResult struct {
+	Adult            bool    `json:"adult"`
+	BackdropPath     string  `json:"backdrop_path"`
+	GenreIds         []int   `json:"genre_ids"`
+	ID               int     `json:"id"`
+	OriginalLanguage string  `json:"original_language"`
+	OriginalTitle    string  `json:"original_title"`
+	Overview         string  `json:"overview"`
+	Popularity       float64 `json:"popularity"`
+	PosterPath       string  `json:"poster_path"`
+	ReleaseDate      string  `json:"release_date"`
+	Title            string  `json:"title"`
+	Video            bool    `json:"video"`
+	VoteAverage      float64 `json:"vote_average"`
+	VoteCount        int     `json:"vote_count"`
+	MediaType        string  `json:"media_type"` // API req doesn't include this, we will add it in our service.
+}
+
 type TMDBSearchMoviesResponse struct {
-	Page    int `json:"page"`
-	Results []struct {
-		Adult            bool    `json:"adult"`
-		BackdropPath     string  `json:"backdrop_path"`
-		GenreIds         []int   `json:"genre_ids"`
-		ID               int     `json:"id"`
-		OriginalLanguage string  `json:"original_language"`
-		OriginalTitle    string  `json:"original_title"`
-		Overview         string  `json:"overview"`
-		Popularity       float64 `json:"popularity"`
-		PosterPath       string  `json:"poster_path"`
-		ReleaseDate      string  `json:"release_date"`
-		Title            string  `json:"title"`
-		Video            bool    `json:"video"`
-		VoteAverage      float64 `json:"vote_average"`
-		VoteCount        int     `json:"vote_count"`
-		MediaType        string  `json:"media_type"` // API req doesn't include this, we will add it in our service.
-	} `json:"results"`
-	TotalPages   int `json:"total_pages"`
-	TotalResults int `json:"total_results"`
+	TMDBSearchResponse[TMDBSearchMovieResult]
+}
+
+type TMDBSearchShowsResult struct {
+	Adult            bool     `json:"adult"`
+	BackdropPath     string   `json:"backdrop_path"`
+	GenreIds         []int    `json:"genre_ids"`
+	ID               int      `json:"id"`
+	OriginCountry    []string `json:"origin_country"`
+	OriginalLanguage string   `json:"original_language"`
+	OriginalName     string   `json:"original_name"`
+	Overview         string   `json:"overview"`
+	Popularity       float64  `json:"popularity"`
+	PosterPath       string   `json:"poster_path"`
+	FirstAirDate     string   `json:"first_air_date"`
+	Name             string   `json:"name"`
+	VoteAverage      float64  `json:"vote_average"`
+	VoteCount        int      `json:"vote_count"`
+	MediaType        string   `json:"media_type"` // API req doesn't include this, we will add it in our service.
 }
 
 type TMDBSearchShowsResponse struct {
-	Page    int `json:"page"`
-	Results []struct {
-		Adult            bool     `json:"adult"`
-		BackdropPath     string   `json:"backdrop_path"`
-		GenreIds         []int    `json:"genre_ids"`
-		ID               int      `json:"id"`
-		OriginCountry    []string `json:"origin_country"`
-		OriginalLanguage string   `json:"original_language"`
-		OriginalName     string   `json:"original_name"`
-		Overview         string   `json:"overview"`
-		Popularity       float64  `json:"popularity"`
-		PosterPath       string   `json:"poster_path"`
-		FirstAirDate     string   `json:"first_air_date"`
-		Name             string   `json:"name"`
-		VoteAverage      float64  `json:"vote_average"`
-		VoteCount        int      `json:"vote_count"`
-		MediaType        string   `json:"media_type"` // API req doesn't include this, we will add it in our service.
-	} `json:"results"`
-	TotalPages   int `json:"total_pages"`
-	TotalResults int `json:"total_results"`
+	TMDBSearchResponse[TMDBSearchShowsResult]
+}
+
+type TMDBSearchPeopleResult struct {
+	Adult              bool    `json:"adult"`
+	Gender             int     `json:"gender"`
+	ID                 int     `json:"id"`
+	KnownForDepartment string  `json:"known_for_department"`
+	Name               string  `json:"name"`
+	OriginalName       string  `json:"original_name"`
+	Popularity         float64 `json:"popularity"`
+	ProfilePath        string  `json:"profile_path"`
+	MediaType          string  `json:"media_type"` // API req doesn't include this, we will add it in our service.
+	KnownFor           []struct {
+		Adult            bool    `json:"adult"`
+		BackdropPath     string  `json:"backdrop_path"`
+		ID               int     `json:"id"`
+		Title            string  `json:"title"`
+		OriginalLanguage string  `json:"original_language"`
+		OriginalTitle    string  `json:"original_title"`
+		Overview         string  `json:"overview"`
+		PosterPath       string  `json:"poster_path"`
+		MediaType        string  `json:"media_type"`
+		GenreIds         []int   `json:"genre_ids"`
+		Popularity       float64 `json:"popularity"`
+		ReleaseDate      string  `json:"release_date"`
+		Video            bool    `json:"video"`
+		VoteAverage      float64 `json:"vote_average"`
+		VoteCount        int     `json:"vote_count"`
+	} `json:"known_for"`
 }
 
 type TMDBSearchPeopleResponse struct {
-	Page    int `json:"page"`
-	Results []struct {
-		Adult              bool    `json:"adult"`
-		Gender             int     `json:"gender"`
-		ID                 int     `json:"id"`
-		KnownForDepartment string  `json:"known_for_department"`
-		Name               string  `json:"name"`
-		OriginalName       string  `json:"original_name"`
-		Popularity         float64 `json:"popularity"`
-		ProfilePath        string  `json:"profile_path"`
-		MediaType          string  `json:"media_type"` // API req doesn't include this, we will add it in our service.
-		KnownFor           []struct {
-			Adult            bool    `json:"adult"`
-			BackdropPath     string  `json:"backdrop_path"`
-			ID               int     `json:"id"`
-			Title            string  `json:"title"`
-			OriginalLanguage string  `json:"original_language"`
-			OriginalTitle    string  `json:"original_title"`
-			Overview         string  `json:"overview"`
-			PosterPath       string  `json:"poster_path"`
-			MediaType        string  `json:"media_type"`
-			GenreIds         []int   `json:"genre_ids"`
-			Popularity       float64 `json:"popularity"`
-			ReleaseDate      string  `json:"release_date"`
-			Video            bool    `json:"video"`
-			VoteAverage      float64 `json:"vote_average"`
-			VoteCount        int     `json:"vote_count"`
-		} `json:"known_for"`
-	} `json:"results"`
-	TotalPages   int `json:"total_pages"`
-	TotalResults int `json:"total_results"`
+	TMDBSearchResponse[TMDBSearchPeopleResult]
+}
+
+type TMDBFindByExternalIdResponse struct {
+	// These are all a TMDBSearchMultiResults so our search func can easily
+	// combine all of them into one []TMDBSearchMultiResults for response
+	// to client (seems not easy to convert to TMDBSearchMultiResults for
+	// concatenation after unmarshalling to correct type).
+	MovieResults  []TMDBSearchMultiResults `json:"movie_results"`
+	PersonResults []TMDBSearchMultiResults `json:"person_results"`
+	TvResults     []TMDBSearchMultiResults `json:"tv_results"`
+	// We don't currently support searching these:
+	// TvseasonResults  []any `json:"tv_season_results"`
+	// TvEpisodeResults []any `json:"tv_episode_results"`
 }
 
 type TMDBContentDetails struct {

--- a/src/routes/(app)/search/[query]/+page.svelte
+++ b/src/routes/(app)/search/[query]/+page.svelte
@@ -141,7 +141,7 @@
       console.debug("search: already running");
       return;
     }
-    if (curPage === maxContentPage) {
+    if (curPage >= maxContentPage) {
       console.debug("search: max page reached");
       return;
     }

--- a/src/routes/(app)/search/[query]/+page.svelte
+++ b/src/routes/(app)/search/[query]/+page.svelte
@@ -160,10 +160,37 @@
       return;
     }
     // Check if first part of query is a supported provider.
-    const p = spl[0]?.toLowerCase();
-    if (!p || (p !== "imdb" && p !== "youtube")) {
-      console.info("checkForExternalIdSearch: Invalid provider found:", p);
-      return;
+    let p = spl[0]?.toLowerCase();
+    switch (p) {
+      // Default names that are supported right out of the box
+      case "imdb":
+      case "tvdb":
+      case "youtube":
+      case "wikidata":
+      case "facebook":
+      case "instagram":
+      case "twitter":
+      case "tiktok":
+        break;
+      // Any aliases we want to support
+      case "i":
+      case "imd":
+        p = "imdb";
+        break;
+      case "wd":
+      case "wdt":
+        p = "wikidata";
+        break;
+      case "yt":
+        p = "youtube";
+        break;
+      case "thetvdb":
+        p = "tvdb";
+        break;
+      // If none match, then is invalid provider.
+      default:
+        console.info("checkForExternalIdSearch: Invalid provider found:", p);
+        return;
     }
     console.debug("checkForExternalIdSearch: Found required params:", p, spl[1]);
     return {
@@ -206,6 +233,7 @@
         console.info("Search: Multiple results from external id search.");
         allSearchResults.push(...data.results);
         searchResults = allSearchResults;
+        curPage++;
       } else if (activeSearchFilter) {
         // If we have a search filter selected, search for just one specific type of content.
         console.log("Search: A filter is active:", activeSearchFilter);


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

You can now use the search bar to lookup movies/tv/people via external ids with this format: `provider:id` eg: `imdb:tt15435876`

If there is only one result (which should be every time?), you will be redirected straight to the content.

Added support for all the ones tmdb supports:

- imdb (aliases: `i`, `imd`)
- tvdb (aliases: `thetvdb`)
- youtube (aliases: `yt`)
- wikidata (aliases: `wd`, `wdt`)
- facebook
- instagram
- twitter
- tiktok

(also simplified some search result structs for the server)

Closes [#564](https://github.com/sbondCo/Watcharr/issues/564)