### PR TITLE
Fix search debounce and styling

### DIFF
--- a/src/lib/img/UserAvatar.svelte
+++ b/src/lib/img/UserAvatar.svelte
@@ -17,8 +17,8 @@
 
 	let { img, avatarDropped = undefined }: Props = $props();
 
-	let bhCanvas: HTMLCanvasElement = $state();
-	let avatarInput: HTMLInputElement = $state();
+	let bhCanvas: HTMLCanvasElement | undefined = $state();
+	let avatarInput: HTMLInputElement | undefined = $state();
 
 	function avatarLoaded() {
 		console.log("avatar loaded.. removing canvas");

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -23,13 +23,14 @@
 
 	let navEl: HTMLElement | undefined = $state();
 	let mainSearchEl: HTMLInputElement | undefined = $state();
-	let searchTimeout: NodeJS.Timeout;
+	let searchTimeout: number;
 	let subMenuShown = $state(false);
 	let filterMenuShown = $state(false);
 	let sortMenuShown = $state(false);
 	let followingMenuShown = $state(false);
 	let detailedMenuShown = $state(false);
 	let tagMenuShown = $state(false);
+	let scroll = window.scrollY;
 
 	function handleProfileClick() {
 		if (!localStorage.getItem("token")) {
@@ -52,7 +53,7 @@
 		)
 			return;
 		clearTimeout(searchTimeout);
-		searchTimeout = setTimeout(
+		searchTimeout = window.setTimeout(
 			() => {
 				const target = ev.target as HTMLInputElement;
 				const query = target?.value.trim();
@@ -136,15 +137,29 @@
 		const bigInput = navEl?.querySelector("input:not(.small)");
 		if (bigInput) {
 			const b = bigInput.getBoundingClientRect();
-			// console.debug("decideOnNavSplit: bigInput bounds:", b);
+			console.debug("decideOnNavSplit: bigInput width:", b.width);
 			if (b.width <= 45) {
 				document.body.classList.add("split-nav");
+				console.debug("decideOnNavSplit: Splitting nav.");
 			} else {
 				document.body.classList.remove("split-nav");
+				console.debug("decideOnNavSplit: Unsplitting nav.");
 			}
 		} else {
 			console.warn("decideOnNavSplit: bigInput not found!", bigInput);
 		}
+	}
+
+	function docOnScroll() {
+		if (scroll > window.scrollY) {
+			navEl?.classList.remove("scrolled-down");
+			document.body.classList.add("nav-shown");
+		} else {
+			navEl?.classList.add("scrolled-down");
+			document.body.classList.remove("nav-shown");
+			closeAllSubMenus();
+		}
+		scroll = window.scrollY;
 	}
 
 	afterNavigate(() => {
@@ -156,19 +171,12 @@
 		if (navEl) {
 			decideOnNavSplit();
 			window.addEventListener("resize", decideOnNavSplit);
+			window.document.addEventListener("scroll", docOnScroll);
 
-			let scroll = window.scrollY;
-			window.document.addEventListener("scroll", (ev: Event) => {
-				if (scroll > window.scrollY) {
-					navEl?.classList.remove("scrolled-down");
-					document.body.classList.add("nav-shown");
-				} else {
-					navEl?.classList.add("scrolled-down");
-					document.body.classList.remove("nav-shown");
-					closeAllSubMenus();
-				}
-				scroll = window.scrollY;
-			});
+			return () => {
+				window.removeEventListener("resize", decideOnNavSplit);
+				window.document.removeEventListener("scroll", docOnScroll);
+			};
 		} else {
 			console.error(
 				"navEl doesn't exist, failed to initialize up/down listener",
@@ -348,7 +356,7 @@
 			justify-content: space-between;
 			align-items: center;
 
-			@media screen and (max-width: 425px) {
+			@media screen and (max-width: 435px) {
 				gap: 15px;
 			}
 
@@ -448,7 +456,7 @@
 				}
 			}
 
-			@media screen and (max-width: 415px) {
+			@media screen and (max-width: 460px) {
 				:global(svg) {
 					display: block;
 				}
@@ -459,7 +467,7 @@
 			}
 		}
 
-		body.split-nav & {
+		:global(body.split-nav) & {
 			.search {
 				opacity: 0;
 				visibility: hidden;

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -26,10 +26,9 @@
 	import { onDestroy, onMount } from "svelte";
 	import Error from "@/lib/Error.svelte";
 	import GamePoster from "@/lib/poster/GamePoster.svelte";
-	import { get } from "svelte/store";
 	import Icon from "@/lib/Icon.svelte";
 	import { afterNavigate, goto } from "$app/navigation";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 
 	type GameWithMediaType = GameSearch & { media_type: "game" };
 	type CombinedResult =
@@ -51,10 +50,6 @@
 
 	const infiniteScrollThreshold = 150;
 	let reqController = new AbortController();
-
-	// let query = $derived(data?.query);
-	// let searchQ = $derived($searchQuery);
-	// let wList = $derived($watchedList);
 
 	async function searchMovies(query: string, page: number) {
 		try {
@@ -347,11 +342,10 @@
 			// Smol timeout to give ui time to render so end of page calc
 			// can be accurate.
 			setTimeout(() => {
-				const p = get(page);
 				// Quick fix, if user navigates away from search page while response is loading,
 				// we don't want to call infiniteScroll or we could end up loading all pages
 				// in the background.
-				if (p.url?.pathname?.toLowerCase()?.startsWith("/search")) {
+				if (page.url?.pathname?.toLowerCase()?.startsWith("/search")) {
 					infiniteScroll();
 				} else {
 					console.debug(
@@ -382,11 +376,6 @@
 		search(store.searchQuery);
 	}
 
-	async function searchUsers(query: string) {
-		return (await axios.get(`/user/search`, { params: { q: query } }))
-			.data as PublicUser[];
-	}
-
 	function setActiveSearchFilter(to: SearchFilterTypes) {
 		if (activeSearchFilter === to) {
 			activeSearchFilter = undefined;
@@ -413,6 +402,11 @@
 			window.addEventListener("scroll", infiniteScroll);
 			console.debug(`Page: ${curPage} / ${maxContentPage}`);
 		}
+	}
+
+	async function searchUsers(query: string) {
+		return (await axios.get(`/user/search`, { params: { q: query } }))
+			.data as PublicUser[];
 	}
 
 	onMount(() => {
@@ -470,8 +464,10 @@
 <!-- <span style="position: sticky;top: 70px;">{curPage} / {maxContentPage}</span> -->
 <div class="content">
 	<div class="inner">
-		{#if store.searchQuery}
-			{#await searchUsers(store.searchQuery) then results}
+		{#if data?.query}
+			<!-- Uses data?.query instead of store.searchQuery,
+			 	so that the debounce of search is respected. -->
+			{#await searchUsers(data?.query) then results}
 				{#if results?.length > 0}
 					<UsersList users={results} />
 				{/if}


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

- Search
  - Fix styling, nav not splitting bar to next line.
  - Fix search debounce not being respected for user search calls.
  - Use svelte 5 `page` state.
- App Layout: Return destroy func in onMount to remove created event listeners.