### PR TITLE
Game: Fix search query parameter when contains special character (space, etc)

### DIFF
--- a/server/game/game.go
+++ b/server/game/game.go
@@ -33,6 +33,8 @@ func (i *IGDB) req(host string, ep string, p map[string]string, b string, resp i
 		return errors.New("using igdbHost without a clientID or accessToken")
 	}
 
+	slog.Debug("IGDB->req: Creating a request.", "ep", ep, "body", b)
+
 	base, err := url.Parse(host)
 	if err != nil {
 		return errors.New("failed to parse api uri")

--- a/server/routes.go
+++ b/server/routes.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -399,7 +400,12 @@ func (b *BaseRouter) addGameRoutes() {
 			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "a query was not provided"})
 			return
 		}
-		games, err := igdb.Search(query)
+		decodedQuery, err := url.QueryUnescape(query)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "query parameter invalid"})
+			return
+		}
+		games, err := igdb.Search(decodedQuery)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return


### PR DESCRIPTION


<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

<!-- Describe changes made here. If changes are visual a screenshot could be useful! -->

Was passing encoded query parameter, now unescaped first, fixing request to igdb.

Fixes #803 

#805 Will fix the rest in next version, since "The Finals" shows as nearly the hundreth result from igdb api call, but without pagination we can't get to it through the ui.
