### PR TITLE
Search by IGDB ID & TMDB ID support

### DIFF
--- a/server/game/game.go
+++ b/server/game/game.go
@@ -183,6 +183,24 @@ func (i *IGDB) Search(q string) (GameSearchResponse, error) {
 	return resp, nil
 }
 
+// Should return same details as `Search`, we both are for search page only minimal details required.
+func (i *IGDB) SearchById(id string) (GameSearchResponse, error) {
+	slog.Debug("IGDB Search called", "id", id)
+	var resp GameSearchResponse
+	err := i.req(
+		igdbHost,
+		"/games",
+		map[string]string{},
+		"fields name, cover.image_id, version_title, summary, first_release_date; where id = "+id+";",
+		&resp,
+	)
+	if err != nil {
+		slog.Error("IGDB Search request failed!", "error", err)
+		return GameSearchResponse{}, errors.New("request failed")
+	}
+	return resp, nil
+}
+
 func (i *IGDB) GameDetails(id string) (GameDetailsResponse, error) {
 	slog.Debug("IGDB GameDetails called", "id", id)
 	var resp []GameDetailsResponse

--- a/server/routes.go
+++ b/server/routes.go
@@ -413,6 +413,20 @@ func (b *BaseRouter) addGameRoutes() {
 		c.JSON(http.StatusOK, games)
 	}))
 
+	// Search for game by id (for search page, same minimal details as /search returned)
+	gamer.GET("/search/:id", cache.CachePage(b.ms, exp, func(c *gin.Context) {
+		if c.Param("id") == "" {
+			c.Status(400)
+			return
+		}
+		games, err := igdb.SearchById(c.Param("id"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, games)
+	}))
+
 	// Game details for game page
 	gamer.GET("/:id", cache.CachePage(b.ms, exp, func(c *gin.Context) {
 		if c.Param("id") == "" {

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -291,6 +291,7 @@
 					// without the debounce going to an incomplete id.
 					// Flesh out if anyone has issues.
 					goto(`/${extProvider.provider}/${extProvider.id}`);
+					return;
 				} else {
 					// Else call tmdb `external id` endpoint
 					console.log("Search: Performing external id search.");

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -198,7 +198,8 @@
 		let p = spl[0]?.toLowerCase();
 		switch (p) {
 			// Default names that are supported right out of the box
-			case "tmdb":
+			case "movie": // tmdb id target
+			case "tv": // tmdb id target
 			case "imdb":
 			case "tvdb":
 			case "youtube":
@@ -226,6 +227,9 @@
 				break;
 			case "game":
 				p = "igdb";
+				break;
+			case "series":
+				p = "tv";
 				break;
 			// If none match, then is invalid provider.
 			default:
@@ -278,7 +282,15 @@
 						return;
 					}
 					allSearchResults.push(...data);
-				} else if (extProvider.provider === "tmdb") {
+				} else if (
+					extProvider.provider === "tv" ||
+					extProvider.provider === "movie"
+				) {
+					// HACK I can't be bothered doing a test api call here,
+					// assuming that people paste the id in, this should work
+					// without the debounce going to an incomplete id.
+					// Flesh out if anyone has issues.
+					goto(`/${extProvider.provider}/${extProvider.id}`);
 				} else {
 					// Else call tmdb `external id` endpoint
 					console.log("Search: Performing external id search.");

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -150,6 +150,23 @@
 		}
 	}
 
+	async function searchGamesById(id: string) {
+		try {
+			const games = await axios.get<GameSearch[]>(`/game/search/${id}`, {
+				signal: reqController.signal,
+			});
+			return {
+				data: games?.data?.map((g) => ({
+					...g,
+					media_type: "game",
+				})) as GameWithMediaType[],
+			};
+		} catch (err) {
+			console.error(`searchGamesById: failed!`, id, err);
+			throw err;
+		}
+	}
+
 	async function searchExternalId(id: string, provider: string) {
 		try {
 			return await axios.get<ContentSearch>(
@@ -181,6 +198,7 @@
 		let p = spl[0]?.toLowerCase();
 		switch (p) {
 			// Default names that are supported right out of the box
+			case "tmdb":
 			case "imdb":
 			case "tvdb":
 			case "youtube":
@@ -189,6 +207,7 @@
 			case "instagram":
 			case "twitter":
 			case "tiktok":
+			case "igdb":
 				break;
 			// Any aliases we want to support
 			case "i":
@@ -204,6 +223,9 @@
 				break;
 			case "thetvdb":
 				p = "tvdb";
+				break;
+			case "game":
+				p = "igdb";
 				break;
 			// If none match, then is invalid provider.
 			default:
@@ -237,42 +259,65 @@
 		reqController = new AbortController();
 		try {
 			if (isExtSearch) {
-				console.log("Search: Performing external id search.");
-				const resp = await searchExternalId(
-					extProvider.id,
-					extProvider.provider,
-				);
-				const data = resp.data;
-				if (!data || !data.results) {
-					console.warn("Search: No results from external id search.");
-					return;
-				}
-				if (
-					data.results.length === 1 &&
-					data.results[0].media_type &&
-					data.results[0].id
-				) {
-					console.info(
-						"Search: Only one result from external id search. Redirecting..",
-						data.results[0],
-					);
-					const mediaType = data.results[0].media_type;
-					if (
-						mediaType !== "movie" &&
-						mediaType !== "tv" &&
-						mediaType !== "person"
-					) {
-						console.info(
-							"Search: Unsupported media type found in only result.. not redirecting.",
-							mediaType,
-						);
-					} else {
-						goto(`/${data.results[0].media_type}/${data.results[0].id}`);
+				if (extProvider.provider === "igdb") {
+					console.log("Search: Performing igdb id search.");
+					const resp = await searchGamesById(extProvider.id);
+					const data = resp.data;
+					const resultsAmt = data.length;
+					if (!data || resultsAmt <= 0) {
+						console.warn("Search: No results from game id search.");
 						return;
 					}
+					if (resultsAmt === 1) {
+						console.info(
+							"Search: Only one result from game id search. Redirecting..",
+							data[0],
+						);
+
+						goto(`/game/${data[0].id}`);
+						return;
+					}
+					allSearchResults.push(...data);
+				} else if (extProvider.provider === "tmdb") {
+				} else {
+					// Else call tmdb `external id` endpoint
+					console.log("Search: Performing external id search.");
+					const resp = await searchExternalId(
+						extProvider.id,
+						extProvider.provider,
+					);
+					const data = resp.data;
+					if (!data || !data.results) {
+						console.warn("Search: No results from external id search.");
+						return;
+					}
+					if (
+						data.results.length === 1 &&
+						data.results[0].media_type &&
+						data.results[0].id
+					) {
+						console.info(
+							"Search: Only one result from external id search. Redirecting..",
+							data.results[0],
+						);
+						const mediaType = data.results[0].media_type;
+						if (
+							mediaType !== "movie" &&
+							mediaType !== "tv" &&
+							mediaType !== "person"
+						) {
+							console.info(
+								"Search: Unsupported media type found in only result.. not redirecting.",
+								mediaType,
+							);
+						} else {
+							goto(`/${data.results[0].media_type}/${data.results[0].id}`);
+							return;
+						}
+					}
+					allSearchResults.push(...data.results);
 				}
 				console.info("Search: Multiple results from external id search.");
-				allSearchResults.push(...data.results);
 				searchResults = allSearchResults;
 				curPage++;
 			} else if (activeSearchFilter) {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

<!-- Describe changes made here. If changes are visual a screenshot could be useful! -->

- Search for igbd id with `igdb` or `game` alias. Example: `igdb:214417`
- Search for a movie or tv show with TMDB id with `movie` or `tv` or `series` aliases. Example: `movie:822119`
  - This search is barebones; No 'search by id' call is done on search page (like other providers), a simple redirect happens to `/<alias>/<id>`, should work for everyone unless typing id manually and debounce timer times out and redirects to an uncompleted <id>.

Closes #778, #804