### PR TITLE
DetailedMenu: Fix wlDetailedView not setting correctly

### DIFF
--- a/src/lib/nav/DetailedMenu.svelte
+++ b/src/lib/nav/DetailedMenu.svelte
@@ -9,6 +9,7 @@
 			store.wlDetailedView = store.wlDetailedView.filter((a) => a !== d);
 		} else {
 			store.wlDetailedView.push(d);
+			store.wlDetailedView = store.wlDetailedView;
 		}
 	}
 </script>


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

- Fix selecting detailed view options not saving them to localStorage (which results in the setting resetting to default after a page refresh).

Fixes #812 