### PR TITLE
feat(theme): add system preference handling to theme configuration

### DIFF
--- a/src/lib/util/helpers.ts
+++ b/src/lib/util/helpers.ts
@@ -1,3 +1,4 @@
+import { browser } from "$app/environment";
 import { store } from "@/store.svelte";
 import {
 	UserPermission,
@@ -295,22 +296,51 @@ export function getOrdinalSuffix(i: number) {
 }
 
 /**
+ * Utility function to handle media queries for theme preferences.
+ */
+
+let mediaQuery: MediaQueryList | null = null;
+if (browser) {
+	mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+}
+const handler = (e: MediaQueryListEvent) => {
+	document.documentElement.classList.toggle("theme-dark", e.matches);
+};
+
+/**
  * Toggle site wide theme.
  * @param theme The theme to switch to.
  * @param updateStore Should the store be updated to new theme?
  * **If set to `false`, state should be manually updated.**
  */
 export function toggleTheme(theme: Theme, updateStore = true) {
-	if (theme === "dark") {
-		document.documentElement.classList.add("theme-dark");
-		if (updateStore) {
-			store.appTheme = "dark";
-		}
-	} else {
-		document.documentElement.classList.remove("theme-dark");
-		if (updateStore) {
-			store.appTheme = "light";
-		}
+	if (updateStore) {
+		store.appTheme = theme;
+	}
+
+	if (!mediaQuery) {
+		return;
+	}
+
+	switch (theme) {
+		case "dark":
+			document.documentElement.classList.add("theme-dark");
+			break;
+		case "light":
+			document.documentElement.classList.remove("theme-dark");
+			break;
+		case "system":
+			document.documentElement.classList.toggle(
+				"theme-dark",
+				mediaQuery.matches,
+			);
+			break;
+	}
+
+	if (theme === "dark" || theme === "light") {
+		mediaQuery.removeEventListener("change", handler);
+	} else if (theme === "system") {
+		mediaQuery.addEventListener("change", handler);
 	}
 }
 

--- a/src/lib/util/helpers.ts
+++ b/src/lib/util/helpers.ts
@@ -1,11 +1,8 @@
-import { browser } from "$app/environment";
-import { store } from "@/store.svelte";
 import {
 	UserPermission,
 	type Icon,
 	type MediaType,
 	type TMDBContentCreditsCrew,
-	type Theme,
 	type TokenClaims,
 	type Watched,
 	type WatchedStatus,
@@ -293,55 +290,6 @@ export function getOrdinalSuffix(i: number) {
 		return "rd";
 	}
 	return "th";
-}
-
-/**
- * Utility function to handle media queries for theme preferences.
- */
-
-let mediaQuery: MediaQueryList | null = null;
-if (browser) {
-	mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-}
-const handler = (e: MediaQueryListEvent) => {
-	document.documentElement.classList.toggle("theme-dark", e.matches);
-};
-
-/**
- * Toggle site wide theme.
- * @param theme The theme to switch to.
- * @param updateStore Should the store be updated to new theme?
- * **If set to `false`, state should be manually updated.**
- */
-export function toggleTheme(theme: Theme, updateStore = true) {
-	if (updateStore) {
-		store.appTheme = theme;
-	}
-
-	if (!mediaQuery) {
-		return;
-	}
-
-	switch (theme) {
-		case "dark":
-			document.documentElement.classList.add("theme-dark");
-			break;
-		case "light":
-			document.documentElement.classList.remove("theme-dark");
-			break;
-		case "system":
-			document.documentElement.classList.toggle(
-				"theme-dark",
-				mediaQuery.matches,
-			);
-			break;
-	}
-
-	if (theme === "dark" || theme === "light") {
-		mediaQuery.removeEventListener("change", handler);
-	} else if (theme === "system") {
-		mediaQuery.addEventListener("change", handler);
-	}
 }
 
 export function parseTokenPayload(): TokenClaims | undefined {

--- a/src/lib/util/theme.ts
+++ b/src/lib/util/theme.ts
@@ -1,0 +1,66 @@
+// App Theme logic.
+
+import { browser } from "$app/environment";
+import { store } from "@/store.svelte";
+import type { Theme } from "@/types";
+
+/**
+ * Utility function to handle media queries for theme preferences.
+ */
+
+const prefersDarkThemeQuery: MediaQueryList | undefined = browser
+	? window.matchMedia("(prefers-color-scheme: dark)")
+	: undefined;
+
+/**
+ * prefersDarkThemeQuery onChange handler.
+ */
+function prefersDarkThemeChanged(e: MediaQueryListEvent) {
+	console.info(
+		"prefersDarkThemeChanged: User preferred theme has changed. prefersDark:",
+		e.matches,
+	);
+	document.documentElement.classList.toggle("theme-dark", e.matches);
+}
+
+/**
+ * Toggle site wide theme.
+ * @param theme The theme to switch to.
+ * @param updateStore Should the store be updated to new theme?
+ * **If set to `false`, state should be manually updated.**
+ */
+export function toggleTheme(theme: Theme, updateStore = true) {
+	if (updateStore) {
+		store.appTheme = theme;
+	}
+
+	switch (theme) {
+		case "dark":
+			document.documentElement.classList.add("theme-dark");
+			break;
+		case "light":
+			document.documentElement.classList.remove("theme-dark");
+			break;
+		case "system":
+			document.documentElement.classList.toggle(
+				"theme-dark",
+				prefersDarkThemeQuery?.matches,
+			);
+			break;
+	}
+
+	if (prefersDarkThemeQuery) {
+		// Always remove first before adding to avoid cases
+		// where we add multiple events at same time.
+		prefersDarkThemeQuery.removeEventListener(
+			"change",
+			prefersDarkThemeChanged,
+		);
+		// If using system theme, add change listener (since
+		// system theme supports live updating when user
+		// preference changes on os or wherever).
+		if (theme === "system") {
+			prefersDarkThemeQuery.addEventListener("change", prefersDarkThemeChanged);
+		}
+	}
+}

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -232,6 +232,13 @@
 					>
 						dark
 					</button>
+					<button
+						class={`plain${selectedTheme === "system" ? " selected" : ""}`}
+						id="system"
+						onclick={() => toggleTheme("system")}
+					>
+						<span>system</span>
+					</button>
 				</div>
 			</div>
 
@@ -498,6 +505,20 @@
 				&#dark {
 					background-color: black;
 					outline-color: white;
+					&:hover {
+						color: white;
+						-webkit-text-stroke: 0.5px white;
+					}
+				}
+
+				&#system {
+					background: linear-gradient(to right bottom, white 50%, black 50.3%);
+					outline-color: black;
+
+					span {
+						mix-blend-mode: difference;
+					}
+
 					&:hover {
 						color: white;
 						-webkit-text-stroke: 0.5px white;

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -7,11 +7,7 @@
 	import Stat from "@/lib/stats/Stat.svelte";
 	import Stats from "@/lib/stats/Stats.svelte";
 	import { updateUserSetting } from "@/lib/util/api";
-	import {
-		getOrdinalSuffix,
-		monthsShort,
-		toggleTheme,
-	} from "@/lib/util/helpers";
+	import { getOrdinalSuffix, monthsShort } from "@/lib/util/helpers";
 	import { store } from "@/store.svelte";
 	import { UserType, type Image, type Profile } from "@/types";
 	import axios from "axios";
@@ -21,6 +17,7 @@
 	import SyncModal from "./modals/SyncModal.svelte";
 	import RegionDropDown from "@/lib/RegionDropDown.svelte";
 	import RatingSetting from "@/lib/rating/RatingSetting.svelte";
+	import { toggleTheme } from "@/lib/util/theme";
 
 	let user = $derived(store.userInfo);
 	let settings = $derived(store.userSettings);
@@ -219,6 +216,13 @@
 				<h4 class="norm">Theme</h4>
 				<div class="row">
 					<button
+						class={`plain${selectedTheme === "system" ? " selected" : ""}`}
+						id="system"
+						onclick={() => toggleTheme("system")}
+					>
+						<span>system</span>
+					</button>
+					<button
 						class={`plain${selectedTheme === "light" ? " selected" : ""}`}
 						id="light"
 						onclick={() => toggleTheme("light")}
@@ -231,13 +235,6 @@
 						onclick={() => toggleTheme("dark")}
 					>
 						dark
-					</button>
-					<button
-						class={`plain${selectedTheme === "system" ? " selected" : ""}`}
-						id="system"
-						onclick={() => toggleTheme("system")}
-					>
-						<span>system</span>
 					</button>
 				</div>
 			</div>

--- a/src/store.svelte.ts
+++ b/src/store.svelte.ts
@@ -12,7 +12,7 @@ import type {
 } from "./types";
 import type { Notification } from "./lib/util/notify";
 import { browser } from "$app/environment";
-import { toggleTheme } from "./lib/util/helpers";
+import { toggleTheme } from "./lib/util/theme";
 
 export const defaultSort = ["DATEADDED", "DOWN"];
 
@@ -238,7 +238,7 @@ function rehydrateStore() {
 	const theme = localStorage.getItem("theme") as Theme;
 	if (theme) {
 		_store.appTheme = theme;
-		toggleTheme(theme, true);
+		toggleTheme(theme, false);
 		console.debug(
 			"rehydrateStore: Restored appTheme:",
 			$state.snapshot(store.appTheme),
@@ -246,7 +246,7 @@ function rehydrateStore() {
 	} else {
 		let defTheme: Theme = "system";
 		_store.appTheme = defTheme;
-		toggleTheme(defTheme, true);
+		toggleTheme(defTheme, false);
 		console.debug(
 			"rehydrateStore: appTheme hydrated from system default (wont save):",
 			defTheme,

--- a/src/store.svelte.ts
+++ b/src/store.svelte.ts
@@ -54,7 +54,7 @@ const _store: Store = $state({
 	notifications: [],
 	activeSort: defaultSort,
 	activeFilters: { type: [], status: [] },
-	appTheme: "light",
+	appTheme: "system",
 	importedList: undefined,
 	parsedImportedList: undefined,
 	searchQuery: "",
@@ -186,7 +186,7 @@ export const clearAllStores = () => {
 	store.watchedList = [];
 	store.notifications = [];
 	store.activeSort = defaultSort;
-	store.appTheme = "light";
+	store.appTheme = "system";
 	store.importedList = undefined;
 	store.parsedImportedList = undefined;
 	store.searchQuery = "";
@@ -238,18 +238,15 @@ function rehydrateStore() {
 	const theme = localStorage.getItem("theme") as Theme;
 	if (theme) {
 		_store.appTheme = theme;
-		toggleTheme(theme, false);
+		toggleTheme(theme, true);
 		console.debug(
 			"rehydrateStore: Restored appTheme:",
 			$state.snapshot(store.appTheme),
 		);
 	} else {
-		let defTheme: Theme = "light";
-		if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-			defTheme = "dark";
-		}
+		let defTheme: Theme = "system";
 		_store.appTheme = defTheme;
-		toggleTheme(defTheme, false);
+		toggleTheme(defTheme, true);
 		console.debug(
 			"rehydrateStore: appTheme hydrated from system default (wont save):",
 			defTheme,

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type Icon =
 	| "tmdb"
 	| "igdb";
 
-export type Theme = "light" | "dark";
+export type Theme = "light" | "dark" | "system";
 
 export type WLDetailedViewOption =
 	| "statusRating"


### PR DESCRIPTION
- Modified the store to handle system `theme` changes and manage deletion and rehydration of the store.
- Added a button to select the `system` theme in the settings.
- Updated the `toggleTheme` function to listen for changes in the `prefers-color-scheme` preference when the 'system' theme is selected.

Fixed #818 