### PR TITLE
feat: improve imdb import

### DIFF
--- a/src/routes/(app)/import/process/+page.svelte
+++ b/src/routes/(app)/import/process/+page.svelte
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   /import/process is for processing the
   selected files data. Here it will be
   displayed and imported.
@@ -166,17 +166,33 @@
 						if (year) {
 							l.year = String(year.getFullYear());
 						}
-						if (type === "movie") {
-							l.type = "movie";
-						} else if (type === "tv series") {
-							l.type = "tv";
-						} else if (type === "tv episode") {
-							l.type = "tv_episode";
-						} else {
-							console.warn("Skipping item with invalid type", `(${type})`, el);
-							anySkipped = true;
-							continue;
+
+						switch (type) {
+							case "movie":
+							case "video":
+							case "tv movie":
+							case "short":
+								l.type = "movie";
+								break;
+							case "tv series":
+							case "tv mini series":
+							case "tv special":
+							case "tv short":
+								l.type = "tv";
+								break;
+							case "tv episode":
+								l.type = "tv_episode";
+								break;
+							default:
+								console.warn(
+									"Skipping item with invalid type",
+									`(${type})`,
+									el,
+								);
+								anySkipped = true;
+								continue;
 						}
+
 						if (imdbId) {
 							l.imdbId = imdbId;
 						}
@@ -709,7 +725,9 @@
 	{#if importMultiItem}
 		<Modal
 			title="Multiple Results Found"
-			desc="Select the correct item for {importMultiItem.original.name}"
+			desc="Select the correct item for {importMultiItem.original
+				.name} {importMultiItem.original.year &&
+				'(' + importMultiItem.original.year + ')'}"
 			onClose={() => {
 				importMultiItem?.callback("closed results modal");
 				importMultiItem = undefined;


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

<!-- Describe changes made here. If changes are visual a screenshot could be useful! -->

This PR makes the IMDb importer more robust by identifying more media types like Direct-to-Video movies, TV Mini Series and more which are all not regconized and thus skipped by the current importer.

It also makes a tiny UI change by adding the year of the imported movie to the "Multiple Results Found" dialog, which makes identifying the actually imported movie more easy and should help to reduce mismatches.

Here is an example screenshot - the new part is the year display in parentheses after the "Select multiple items for ..." - the year and parentheses are only shown when the data is available.

![2025-04-28-142835_hyprshot](https://github.com/user-attachments/assets/8a96fb39-7828-444e-82b8-24eb7c86ab22)

