### PR TITLE
Search shortcut & add missing keys that search handler should ignore

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -43,13 +43,25 @@
 
 	function handleSearch(ev: KeyboardEvent) {
 		if (
+			ev.key === "ContextMenu" ||
+			ev.key === "Home" ||
+			ev.key === "End" ||
+			ev.key === "PageDown" ||
+			ev.key === "PageUp" ||
+			ev.key === "NumLock" ||
+			ev.key === "Escape" ||
 			ev.key === "Tab" ||
 			ev.key === "CapsLock" ||
 			ev.key === "OS" ||
 			ev.key === "ArrowLeft" ||
 			ev.key === "ArrowRight" ||
 			ev.key === "ArrowUp" ||
-			ev.key === "ArrowDown"
+			ev.key === "ArrowDown" ||
+			ev.key === "Control" ||
+			ev.key === "Alt" ||
+			ev.key === "AltGraph" ||
+			ev.key === "Shift" ||
+			ev.key === "Meta"
 		)
 			return;
 		clearTimeout(searchTimeout);

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -175,15 +175,19 @@
 	}
 
 	function focusSearch() {
-		if (!mainSearchEl) {
-			console.warn("focusSearch: mainSearchEl not defined!");
-			return;
+		try {
+			if (!mainSearchEl) {
+				console.warn("focusSearch: mainSearchEl not defined!");
+				return;
+			}
+			if (document.activeElement === mainSearchEl) {
+				console.debug("focusSearch: mainSearchEl is already focused.");
+				return;
+			}
+			mainSearchEl.focus();
+		} catch (err) {
+			console.error("focusSearch: Failed!", err);
 		}
-		if (document.activeElement === mainSearchEl) {
-			console.debug("focusSearch: mainSearchEl is already focused.");
-			return;
-		}
-		mainSearchEl.focus();
 	}
 
 	function handleGlobalKeybind(ev: KeyboardEvent) {

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -174,6 +174,29 @@
 		scroll = window.scrollY;
 	}
 
+	function focusSearch() {
+		if (!mainSearchEl) {
+			console.warn("focusSearch: mainSearchEl not defined!");
+			return;
+		}
+		if (document.activeElement === mainSearchEl) {
+			console.debug("focusSearch: mainSearchEl is already focused.");
+			return;
+		}
+		mainSearchEl.focus();
+	}
+
+	function handleGlobalKeybind(ev: KeyboardEvent) {
+		switch (ev.key.toLowerCase()) {
+			case "s":
+				if (ev.ctrlKey) {
+					ev.preventDefault();
+					focusSearch();
+				}
+				break;
+		}
+	}
+
 	afterNavigate(() => {
 		decideOnNavSplit();
 		closeAllSubMenus();
@@ -184,10 +207,12 @@
 			decideOnNavSplit();
 			window.addEventListener("resize", decideOnNavSplit);
 			window.document.addEventListener("scroll", docOnScroll);
+			window.document.addEventListener("keydown", handleGlobalKeybind);
 
 			return () => {
 				window.removeEventListener("resize", decideOnNavSplit);
 				window.document.removeEventListener("scroll", docOnScroll);
+				window.document.removeEventListener("keydown", handleGlobalKeybind);
 			};
 		} else {
 			console.error(


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

- (fix) handleSearch: Add missing keys that we should ignore (some special keys were still triggering a search)
- (new) Create global keybing handler, ctrl+s search bind

Fixes [#679](https://github.com/sbondCo/Watcharr/issues/679)