### PR TITLE
import: Perfect matching now takes Year into account if provided

### DIFF
--- a/server/import.go
+++ b/server/import.go
@@ -28,6 +28,7 @@ var (
 
 type ImportRequest struct {
 	Name             string           `json:"name"`
+	Year             int              `json:"year"`
 	TmdbID           int              `json:"tmdbId"`
 	Type             ContentType      `json:"type"`
 	Rating           float64          `json:"rating" binding:"max=10"`
@@ -51,6 +52,7 @@ type ImportResponse struct {
 }
 
 func importContent(db *gorm.DB, userId uint, ar ImportRequest) (ImportResponse, error) {
+	slog.Debug("import: Processing request:", "request", ar)
 	// If tmdbId and type passed in request body
 	// we dont need to use a search tmdb request.
 	// Retrieve the details directly.
@@ -139,28 +141,56 @@ func importContent(db *gorm.DB, userId uint, ar ImportRequest) (ImportResponse, 
 		// If there are multiple responses, but only one item
 		// from the results is a 100% match for the imported
 		// items name, then consider successful match with that.
-		var perfectMatch TMDBSearchMultiResults
+		perfectMatches := []TMDBSearchMultiResults{}
 		for _, r := range pMatches {
 			itemName := r.Name
 			if itemName == "" {
 				itemName = r.Title
 			}
-			if strings.EqualFold(itemName, ar.Name) {
-				slog.Debug("import: multiple results processing: found a perfectMatch", "match", r)
-				if perfectMatch.ID != 0 {
-					// If perfect match has been set before..
-					// quit looking and just show all results.
-					slog.Debug("import: multiple results processing: Second perfectMatch found.. returning all results")
-					return ImportResponse{Type: IMPORT_MULTI, Results: pMatches}, nil
+			itemReleaseYear := 0
+			// Only parse dates to find year if the import request has provided
+			// a year to comparisons.. otherwise don't do it to save some performance juice.
+			if ar.Year != 0 {
+				itemReleaseDateStr := r.ReleaseDate
+				if itemReleaseDateStr == "" {
+					itemReleaseDateStr = r.FirstAirDate
 				}
-				perfectMatch = r
+				if itemReleaseDate, err := time.Parse("2006-01-02", itemReleaseDateStr); err == nil {
+					itemReleaseYear = itemReleaseDate.Year()
+				} else {
+					slog.Error("import: failed to check item release year, it can't be used for matching", "error", err, "item", r)
+				}
+			}
+			if strings.EqualFold(itemName, ar.Name) {
+				slog.Debug("import: multiple results processing: found a perfect name match", "itemReleaseYear", itemReleaseYear, "ar.Year", ar.Year, "match", r)
+				// If we have a year for comparison, force a check to compare them for a
+				// match to be deemed perfect.
+				// `itemReleaseYear` can only ever have a value if `ar.Year` has one, so this
+				// check is safe as is.
+				if itemReleaseYear != 0 || ar.Year != 0 {
+					if itemReleaseYear == ar.Year {
+						perfectMatches = append(perfectMatches, r)
+						slog.Debug("import: multiple results processing: name match also matched year")
+					} else {
+						slog.Debug("import: multiple results processing: name match didnt match year")
+					}
+					continue
+				}
+				// Otherwise, if we don't have valid dates to compare, append the perfect name match anyways.
+				slog.Debug("import: multiple results processing: name match didn't have valid release year, adding to matches anyways")
+				perfectMatches = append(perfectMatches, r)
 			}
 		}
 		// If one perfect match found, import it
-		if perfectMatch.ID != 0 {
+		pmLen := len(perfectMatches)
+		if pmLen == 1 && perfectMatches[0].ID != 0 {
 			slog.Debug("import: importing from perfect match")
-			return successfulImport(db, userId, perfectMatch.ID, ContentType(perfectMatch.MediaType), ar)
+			return successfulImport(db, userId, perfectMatches[0].ID, ContentType(perfectMatches[0].MediaType), ar)
+		} else if pmLen > 1 {
+			slog.Debug("import: returning multiple perfect matches")
+			return ImportResponse{Type: IMPORT_MULTI, Results: perfectMatches}, nil
 		}
+		slog.Debug("import: returning all potential matches")
 		return ImportResponse{Type: IMPORT_MULTI, Results: pMatches}, nil
 	} else {
 		slog.Debug("import: success.. only found one result")

--- a/src/routes/(app)/import/+page.svelte
+++ b/src/routes/(app)/import/+page.svelte
@@ -225,7 +225,7 @@
 					}
 				}
 				if (h.year) {
-					t.year = h.year;
+					t.year = Number(h.year);
 				}
 				if (ratingsEntry && ratingsEntry?.userRating) {
 					t.rating = Number(ratingsEntry.userRating);
@@ -314,7 +314,7 @@
 				const t: ImportedList = {
 					tmdbId: v.content.tmdbId,
 					name: v.content.title,
-					year: new Date(v.content.release_date)?.getFullYear()?.toString(),
+					year: new Date(v.content.release_date)?.getFullYear(),
 					type: v.content.type,
 					rating: v.rating,
 					status: v.status,

--- a/src/routes/(app)/import/process/+page.svelte
+++ b/src/routes/(app)/import/process/+page.svelte
@@ -74,7 +74,7 @@
 					const l: ImportedList = { name: el };
 					const year = el.match(yearRegex);
 					if (year && year.length > 0) {
-						l.year = year[0].replaceAll(/\(|\)/g, "");
+						l.year = Number(year[0].replaceAll(/\(|\)/g, ""));
 						l.name = l.name.replace(yearRegex, "").trim();
 					}
 					rList.push(l);
@@ -98,7 +98,7 @@
 							? new Date(el["Release Date"])
 							: undefined;
 						if (year) {
-							l.year = String(year.getFullYear());
+							l.year = year.getFullYear();
 						}
 						if (el.Type === "movie" || el.Type === "tv") {
 							l.type = el.Type;
@@ -164,7 +164,7 @@
 							? new Date(el["Release Date"])
 							: undefined;
 						if (year) {
-							l.year = String(year.getFullYear());
+							l.year = year.getFullYear();
 						}
 
 						switch (type) {
@@ -401,7 +401,7 @@
 		const lo = { name: ev.currentTarget.value } as ImportedList;
 		const yearEl = document.getElementById("addYear") as HTMLInputElement;
 		if (yearEl?.value) {
-			lo.year = yearEl.value;
+			lo.year = Number(yearEl.value);
 		}
 		rList.push(lo);
 		rList = rList;
@@ -511,8 +511,7 @@
 						w.content?.type === "movie"
 							? w.content?.release_date
 							: w.content?.first_air_date;
-					if (release)
-						item.year = String(new Date(Date.parse(release)).getFullYear());
+					if (release) item.year = new Date(Date.parse(release)).getFullYear();
 					item.type = w.content?.type;
 					store.watchedList.push(w);
 				}

--- a/src/types.ts
+++ b/src/types.ts
@@ -906,7 +906,7 @@ export interface ImportResponse {
 export interface ImportedList {
 	tmdbId?: number;
 	name: string;
-	year?: string;
+	year?: number;
 	type?: ContentType;
 	state?: string;
 	rating?: number;


### PR DESCRIPTION
avoiding muli result responses

perfect matches are also collected (before only one was allowed to perfect match) and all are returned if multiple

Fixes #914
