### PR TITLE
fix bug on return from blurhash.Encode

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -58,7 +58,7 @@ func getBlurHash(img io.Reader) (string, error) {
 		slog.Error("getBlurHash decoding image failed", "error", err)
 		return "", errors.New("decoding image failed")
 	}
-	bh, _ := blurhash.Encode(6, 5, i)
+	bh, err := blurhash.Encode(6, 5, i)
 	if err != nil {
 		// Handle errors
 		slog.Error("getBlurHash generation failed", "error", err)


### PR DESCRIPTION
### Changes made

One-line fix when calling blurhash.Encode, as (unlike Decode) the second return is the error.

https://github.com/bbrks/go-blurhash/blob/master/encode_test.go#L34