### PR TITLE
feat: Display air date for unaired episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ These changes are awaiting release:
 ## Changed
 
 - HTTP Requests: Replace `axios` with `Fetch`.
+- Show `Airs On` date for episodes that have yet to air (thanks [@KarpachMarko]!).
 
 ## Fixed
 
@@ -1858,3 +1859,4 @@ Welcome to Watcharr :popcorn:, hope it is enjoyed and improves anyone's experien
 [@4qu4r1um]: https://github.com/4qu4r1um
 [@goestav]: https://github.com/goestav
 [@tonghuaroot]: https://github.com/tonghuaroot
+[@KarpachMarko]: https://github.com/KarpachMarko

--- a/src/lib/SeasonsListEpisode.svelte
+++ b/src/lib/SeasonsListEpisode.svelte
@@ -24,6 +24,10 @@
 
 	let isHidden: boolean = $state(!!store?.userSettings?.hideSpoilers);
 
+    const isUnaired = $derived(
+      ep.air_date && new Date(ep.air_date).getTime() > new Date().getTime()
+    );
+
 	function updateWatchedEpisode(status?: WatchedStatus, rating?: number) {
 		if (!watchedItem) {
 			console.error(
@@ -203,6 +207,11 @@
 				{Math.round(ep.vote_average * 10) / 10}
 			</span>
 		</div>
+		{#if isUnaired}
+			<span class="episode-air-date"
+				>Airs on {new Date(ep.air_date).toLocaleDateString()}</span
+			>
+		{/if}
 		<span class="overview">{ep.overview}</span>
 	</div>
 	{#if watchedItem}
@@ -308,6 +317,15 @@
 						line-height: 0.7;
 					}
 				}
+			}
+
+			.episode-air-date {
+				font-size: 14px;
+				color: $text-color-accent;
+				padding: 0 2px;
+				text-transform: lowercase;
+				font-variant: small-caps;
+				font-weight: bold;
 			}
 		}
 

--- a/src/lib/SeasonsListEpisode.svelte
+++ b/src/lib/SeasonsListEpisode.svelte
@@ -24,9 +24,9 @@
 
 	let isHidden: boolean = $state(!!store?.userSettings?.hideSpoilers);
 
-    const isUnaired = $derived(
-      ep.air_date && new Date(ep.air_date).getTime() > new Date().getTime()
-    );
+	const isUnaired = $derived(
+		ep.air_date && new Date(ep.air_date).getTime() > new Date().getTime(),
+	);
 
 	function updateWatchedEpisode(status?: WatchedStatus, rating?: number) {
 		if (!watchedItem) {

--- a/src/lib/season/SeasonsListEpisode.svelte
+++ b/src/lib/season/SeasonsListEpisode.svelte
@@ -11,6 +11,7 @@
 	import { store } from "@/store.svelte";
 	import { removeWatchedEpisode, updateWatchedEpisode } from "./api";
 	import { onMount } from "svelte";
+	import { toRelativeDate } from "../util/helpers";
 
 	interface Props {
 		ep: TMDBSeasonDetailsEpisode;
@@ -29,9 +30,22 @@
 
 	let isHidden: boolean = $state(!!store?.userSettings?.hideSpoilers);
 
-	const isUnaired = $derived(
-		ep.air_date && new Date(ep.air_date).getTime() > new Date().getTime(),
-	);
+	const airDate: Date | undefined = $derived.by(() => {
+		if (!ep.air_date) {
+			return;
+		}
+		const d = new Date(ep.air_date);
+		if (isNaN(d.getTime())) {
+			return;
+		}
+		return d;
+	});
+	const isUnaired: boolean = $derived.by(() => {
+		if (!airDate) {
+			return false;
+		}
+		return airDate.getTime() > new Date().getTime();
+	});
 
 	/**
 	 * Re-sets `isHidden` state.
@@ -117,18 +131,23 @@
 					>
 				{/if}
 			</span>
-			<span
-				class="rating"
-				title={`TMDB Rating: ${ep.vote_average} out of 10 (based on ${ep.vote_count} votes)`}
-			>
-				<span>*</span>
-				{Math.round(ep.vote_average * 10) / 10}
-			</span>
+			{#if ep.vote_count <= 0 && isUnaired}
+				<!-- If no votes (and subsequently no rating) AND episode is
+				 unaired, no need to show the rating star. -->
+			{:else}
+				<span
+					class="rating"
+					title={`TMDB Rating: ${ep.vote_average} out of 10 (based on ${ep.vote_count} votes)`}
+				>
+					<span>*</span>
+					{Math.round(ep.vote_average * 10) / 10}
+				</span>
+			{/if}
 		</div>
-		{#if isUnaired}
-			<span class="episode-air-date"
-				>Airs on {new Date(ep.air_date).toLocaleDateString()}</span
-			>
+		{#if isUnaired && airDate}
+			<span class="episode-air-date">
+				Airs on {toRelativeDate(airDate)}
+			</span>
 		{/if}
 		<span class="overview">{ep.overview}</span>
 	</div>

--- a/src/lib/season/SeasonsListEpisode.svelte
+++ b/src/lib/season/SeasonsListEpisode.svelte
@@ -29,6 +29,10 @@
 
 	let isHidden: boolean = $state(!!store?.userSettings?.hideSpoilers);
 
+	const isUnaired = $derived(
+		ep.air_date && new Date(ep.air_date).getTime() > new Date().getTime(),
+	);
+
 	/**
 	 * Re-sets `isHidden` state.
 	 */
@@ -121,6 +125,11 @@
 				{Math.round(ep.vote_average * 10) / 10}
 			</span>
 		</div>
+		{#if isUnaired}
+			<span class="episode-air-date"
+				>Airs on {new Date(ep.air_date).toLocaleDateString()}</span
+			>
+		{/if}
 		<span class="overview">{ep.overview}</span>
 	</div>
 	{#if watchedItem}
@@ -221,6 +230,15 @@
 						line-height: 0.7;
 					}
 				}
+			}
+
+			.episode-air-date {
+				font-size: 14px;
+				color: $text-color-accent;
+				padding: 0 2px;
+				text-transform: lowercase;
+				font-variant: small-caps;
+				font-weight: bold;
 			}
 		}
 


### PR DESCRIPTION
This pull request enhances the user experience by displaying the air date for upcoming episodes.

  Changes:

   * Displays Air Date: For episodes with a future air date, the component now displays "Airs on [date]".
   * Placement: The air date is positioned above the episode description, which is often empty for unaired episodes.
   * Styling: The air date text is styled to be slightly smaller and uses a muted color to differentiate it from other information.

  How to Test:

   1. Navigate to a TV show that has upcoming episodes.
   2. View the list of episodes for a season that has not yet fully aired.
   3. Confirm that episodes with a future air date now display the "Airs on..." text above the description.
   4. Verify that the text is styled correctly (smaller, muted color).