### PR TITLE
Fix 3.0.0 1

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -212,6 +212,13 @@ func (c *ServerConfig) SaveTwitchConfig(newt igdb.IGDB) error {
 	return nil
 }
 
+func (c *ServerConfig) TwitchEnabled() bool {
+	if c.TWITCH.ClientID != nil && c.TWITCH.ClientSecret != nil {
+		return true
+	}
+	return false
+}
+
 // Read config file
 // Calls generateConfig if file doesn't exist
 func read() (*ServerConfig, error) {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -81,7 +81,7 @@ type ServerConfig struct {
 
 	SONARR []cfgmodel.SonarrSettings `json:",omitempty"`
 	RADARR []cfgmodel.RadarrSettings `json:",omitempty"`
-	TWITCH igdb.IGDB                 `json:",omitempty"`
+	TWITCH igdb.IGDB                 `json:",omitzero"`
 
 	// Optional: Schedule for tasks.
 	TASK_SCHEDULE map[string]int `json:",omitempty"`

--- a/server/feature/feature/feature.go
+++ b/server/feature/feature/feature.go
@@ -27,7 +27,7 @@ func NewService(cfg *config.ServerConfig) *Service {
 // which btns should be shown, etc.
 func (s *Service) GetEnabledFeatures(userPerms int) ServerFeatures {
 	var f ServerFeatures
-	if s.cfg.TWITCH.ClientID != nil && s.cfg.TWITCH.ClientSecret != nil {
+	if s.cfg.TwitchEnabled() {
 		f.Games = true
 	}
 	if permission.Has(userPerms, entity.PERM_REQUEST_CONTENT) {

--- a/server/feature/search/search.go
+++ b/server/feature/search/search.go
@@ -108,16 +108,18 @@ func (s *Service) searchMulti(
 		)
 	}
 	// IGDB
-	igdbRes, err := s.cfg.TWITCH.Search(query)
-	if err != nil {
-		slog.Error("SearchMulti: Failed to search igdb!", "error", err)
-		return errors.New("content request failed")
-	}
-	for _, v := range igdbRes {
-		resp.Results = append(
-			resp.Results,
-			v.AsMedia(),
-		)
+	if s.cfg.TwitchEnabled() {
+		igdbRes, err := s.cfg.TWITCH.Search(query)
+		if err != nil {
+			slog.Error("SearchMulti: Failed to search igdb!", "error", err)
+			return errors.New("content request failed")
+		}
+		for _, v := range igdbRes {
+			resp.Results = append(
+				resp.Results,
+				v.AsMedia(),
+			)
+		}
 	}
 	resp.Page = tmdbRes.Page
 	resp.TotalPages = tmdbRes.TotalPages

--- a/server/feature/search/search.go
+++ b/server/feature/search/search.go
@@ -107,8 +107,8 @@ func (s *Service) searchMulti(
 			v.AsMedia(),
 		)
 	}
-	// IGDB
-	if s.cfg.TwitchEnabled() {
+	// IGDB (we will only get results for the first page)
+	if page == 1 && s.cfg.TwitchEnabled() {
 		igdbRes, err := s.cfg.TWITCH.Search(query)
 		if err != nil {
 			slog.Error("SearchMulti: Failed to search igdb!", "error", err)

--- a/server/media/igdb/igdb.go
+++ b/server/media/igdb/igdb.go
@@ -39,7 +39,7 @@ type IGDB struct {
 	ClientID           *string   `json:"clientId,omitempty"`
 	ClientSecret       *string   `json:"clientSecret,omitempty"`
 	AccessToken        string    `json:"accessToken,omitempty"`
-	AccessTokenExpires time.Time `json:"accessTokenExpires,omitempty"`
+	AccessTokenExpires time.Time `json:"accessTokenExpires,omitzero"`
 	onTokenRefreshed   *func()
 }
 

--- a/server/media/tmdb/structs.go
+++ b/server/media/tmdb/structs.go
@@ -549,7 +549,7 @@ func (t *TMDBShowDetails) AsMedia() domain.Media {
 			Name:         v.Name,
 			EpisodeCount: v.EpisodeCount,
 		}
-		if releaseDate, err := time.Parse("2006-01-02", t.FirstAirDate); err == nil {
+		if releaseDate, err := time.Parse("2006-01-02", v.AirDate); err == nil {
 			ms.ReleaseDate = releaseDate
 		} else {
 			slog.Error("AsMedia: Failed to parse release date", "name", m.Name, "error", err)

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -109,6 +109,12 @@
 			return `${baseURL}/${media.poster.path}`;
 		}
 
+		// Logic below uses `extPosterPath`, so check here first.
+		// If it doesn't exist, return undefined.
+		if (!media.extPosterPath) {
+			return;
+		}
+
 		if (
 			media.type == MediaTypeE.tmdbMovie ||
 			media.type == MediaTypeE.tmdbShow

--- a/src/lib/poster/Poster.svelte
+++ b/src/lib/poster/Poster.svelte
@@ -303,7 +303,7 @@
 	class={`${posterActive ? "active " : ""}${watched?.pinned ? "pinned " : ""}${hideIfNotOnList && !watched ? "hidden " : ""}`}
 >
 	<div
-		class={`container${!poster ? " details-shown" : ""}`}
+		class={`container${!poster || posterImgLoaded == -1 ? " details-shown" : ""}`}
 		bind:this={containerEl}
 	>
 		{#if poster}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -396,6 +396,14 @@
 			justify-content: space-between;
 			align-items: center;
 
+			a,
+			.btns {
+				/* This makes the logo on left and icons on right the same
+				width, ensuring the main search bar can stay truly centered
+				when possible. */
+				flex: 1;
+			}
+
 			@media screen and (max-width: 435px) {
 				gap: 15px;
 			}
@@ -509,6 +517,8 @@
 
 		:global(body.split-nav) & {
 			.search {
+				/* We hide with visibility: hidden, so the decideOnNavSplit can
+				still get the search width for it's decision logic. */
 				opacity: 0;
 				visibility: hidden;
 			}
@@ -549,6 +559,7 @@
 		.btns {
 			display: flex;
 			flex-flow: row;
+			justify-content: end;
 			/* gap: 20px; */
 
 			button.other {

--- a/src/routes/(app)/server/+page.svelte
+++ b/src/routes/(app)/server/+page.svelte
@@ -311,7 +311,8 @@
 						<SettingButton
 							title="Twitch"
 							desc="Twitch application credentials for enabling game support (via IGDB)."
-							icon={Object.keys(serverConfig.TWITCH).length > 0
+							icon={serverConfig.TWITCH &&
+							Object.keys(serverConfig.TWITCH).length > 0
 								? "arrow"
 								: "add"}
 							onClick={() => {

--- a/src/routes/(app)/server/modals/TwitchModal.svelte
+++ b/src/routes/(app)/server/modals/TwitchModal.svelte
@@ -7,13 +7,13 @@
 	import axios from "axios";
 
 	interface Props {
-		cfg: TwitchSettings;
+		cfg?: TwitchSettings;
 		onClose: () => void;
 	}
 
-	let { cfg = $bindable(), onClose }: Props = $props();
+	let { cfg = {}, onClose }: Props = $props();
 
-	let error: string = $state();
+	let error: string | undefined = $state();
 	let formDisabled = false;
 
 	function checkForm() {
@@ -76,7 +76,8 @@
 			<input
 				type="text"
 				placeholder="yrbrrakvgbce99fzjsidkfoalsk9eee"
-				bind:value={cfg.clientId}
+				value={cfg.clientId}
+				oninput={(e) => (cfg.clientId = e.currentTarget.value)}
 				disabled={formDisabled}
 			/>
 		</Setting>
@@ -84,7 +85,8 @@
 			<input
 				type="text"
 				placeholder="yrbralsodkfishfzpajdkflqoefeee"
-				bind:value={cfg.clientSecret}
+				value={cfg.clientSecret}
+				oninput={(e) => (cfg.clientSecret = e.currentTarget.value)}
 				disabled={formDisabled}
 			/>
 		</Setting>

--- a/src/types.ts
+++ b/src/types.ts
@@ -573,7 +573,7 @@ export interface ServerConfig {
 	PLEX_MACHINE_ID: string;
 	SONARR: SonarrSettings[];
 	RADARR: RadarrSettings[];
-	TWITCH: TwitchSettings;
+	TWITCH?: TwitchSettings;
 	DEBUG: boolean;
 }
 
@@ -617,8 +617,8 @@ export interface RadarrSettingsPublicResponseResult
 	extends ArrSettingsPublicResponseBase {}
 
 export interface TwitchSettings {
-	clientId: string;
-	clientSecret: string;
+	clientId?: string;
+	clientSecret?: string;
 }
 
 export interface TrustedHeaderAuthSetting {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

- [x] Multi search is broken when game is not configured (multi search shouldnt do games if not configured)
- [x] Multi search: Because we don't have page support for games, the second page of multi results includes duplicate games from the first page again (search 'Mario' to see a very apparent issue.. should we never get a second page of games for multi search anyways?)
- [x] Chrome: Poster image when image fails to load shows the img failed icon
- [x] Seasons: Years are all the same
- [x] (been "broken" since 1.0) Search: Is not centered in middle of nav and moves when you go on other pages because of the right icons change (does it look weird if you center it in the nav where it doesn't care about icons size)
