### PR TITLE
Fix syncing/import, restoreWatched renamed and now works like it used to so we can return different exists errors

### DIFF
--- a/server/domain/watched.go
+++ b/server/domain/watched.go
@@ -1,11 +1,19 @@
 package domain
 
 import (
+	"errors"
 	"time"
 
 	"github.com/sbondCo/Watcharr/database/entity"
 	"github.com/sbondCo/Watcharr/feature/watched/watchedutil"
 	"github.com/sbondCo/Watcharr/util"
+)
+
+var (
+	// Watched entry already exists.
+	ErrWatchedExists = errors.New("watched entry exists")
+	// Watched entry exists as a soft deleted record (..and restore wasn't attempted by choice).
+	ErrWatchedExistsSoftDeleted = errors.New("watched entry exists soft deleted")
 )
 
 type WatchedSort string
@@ -43,6 +51,19 @@ type WatchedGetPageExtraProps struct {
 	WatchedIds []int
 	// Only get watched items where content matches this query.
 	Query string
+}
+
+type WatchedAddExtraProps struct {
+	// The type of activity this is (will be added to db as this type).
+	ActivityType entity.ActivityType
+	// When watched entry to db, if a unique constraint is hit, should
+	// we skip the restoration logic (bring back soft deleted record)?
+	// - Syncing logic may use this field as it might not make sense to restore
+	// a record when doing a task like a regular sync, otherwise the user could
+	// soft delte a record and then have it come back when they next sync.
+	// - Importers however probably shouldn't use this flag as true because
+	// importing will always be a manual decision.
+	DontRestore bool
 }
 
 type WatchedDto struct {

--- a/server/feature/imprt/import.go
+++ b/server/feature/imprt/import.go
@@ -19,7 +19,7 @@ import (
 )
 
 type WatchedProvider interface {
-	AddWatched(userId uint, ar domain.WatchedAddRequest, at entity.ActivityType) (entity.Watched, error)
+	AddWatched(userId uint, ar domain.WatchedAddRequest, extraProps domain.WatchedAddExtraProps) (entity.Watched, error)
 	GetWatchedItemByTmdbId(userId uint, tmdbId uint, contentType entity.ContentType) (entity.Watched, error)
 }
 
@@ -243,17 +243,22 @@ func (s *Service) SuccessfulImport(
 			}
 		}
 	}
-	w, err := s.wp.AddWatched(userId, domain.WatchedAddRequest{
-		Status:      status,
-		TMDBID:      contentId,
-		ContentType: contentType,
-		Rating:      ar.Rating,
-		Thoughts:    ar.Thoughts,
-		WatchedDate: wDate,
-	}, entity.IMPORTED_WATCHED)
+	w, err := s.wp.AddWatched(
+		userId,
+		domain.WatchedAddRequest{
+			Status:      status,
+			TMDBID:      contentId,
+			ContentType: contentType,
+			Rating:      ar.Rating,
+			Thoughts:    ar.Thoughts,
+			WatchedDate: wDate,
+		},
+		domain.WatchedAddExtraProps{
+			ActivityType: entity.IMPORTED_WATCHED,
+		})
 	if err != nil {
-		if err.Error() == "content already on watched list" {
-			slog.Error("successfulImport: unique constraint hit.. show must already be on watch list", "error", err)
+		if errors.Is(err, domain.ErrWatchedExists) {
+			slog.Error("successfulImport: Must already be on watch list", "error", err)
 			return domain.ImportResponse{Type: domain.IMPORT_EXISTS}, nil
 		}
 		slog.Error("successfulImport: Failed to add content as watched", "error", err)

--- a/server/feature/jellyfin/jellyfin_sync.go
+++ b/server/feature/jellyfin/jellyfin_sync.go
@@ -41,7 +41,7 @@ type JellyfinSyncResponse struct {
 }
 
 type WatchedProvider interface {
-	AddWatched(userId uint, ar domain.WatchedAddRequest, at entity.ActivityType) (entity.Watched, error)
+	AddWatched(userId uint, ar domain.WatchedAddRequest, extraProps domain.WatchedAddExtraProps) (entity.Watched, error)
 }
 
 type WatchedSeasonProvider interface {
@@ -132,18 +132,44 @@ func (s *SyncService) startJellyfinSync(
 				job.UpdateJobCurrentTask(jobId, userId, "syncing "+v.Name)
 
 				// 2. Imported watched movie
-				w, err := s.wp.AddWatched(userId, domain.WatchedAddRequest{
-					Status:      entity.FINISHED,
-					ContentType: util.SupportedMediaMovie,
-					TMDBID:      tmdbId,
-					WatchedDate: v.UserData.LastPlayedDate,
-				}, entity.IMPORTED_WATCHED_JF)
+				w, err := s.wp.AddWatched(
+					userId,
+					domain.WatchedAddRequest{
+						Status:      entity.FINISHED,
+						ContentType: util.SupportedMediaMovie,
+						TMDBID:      tmdbId,
+						WatchedDate: v.UserData.LastPlayedDate,
+					}, domain.WatchedAddExtraProps{
+						ActivityType: entity.IMPORTED_WATCHED_JF,
+						DontRestore:  true,
+					})
 				if err != nil {
-					if err.Error() == "content already on watched list" {
-						slog.Error("jellyfinSyncWatched: Unique constraint hit.. content must already be on watch list.", "movie_name", v.Name, "movie_ids", v.ProviderIds, "user_id", userId)
+					if errors.Is(err, domain.ErrWatchedExists) {
+						slog.Info("jellyfinSyncWatched: Content already exists on list.",
+							"movie_name", v.Name,
+							"movie_ids", v.ProviderIds,
+							"user_id", userId)
+					} else if errors.Is(err, domain.ErrWatchedExistsSoftDeleted) {
+						slog.Warn("jellyfinSyncWatched: Movie exists on list soft deleted.")
+						job.AddJobError(
+							jobId,
+							userId,
+							"failed to add movie "+
+								v.Name+
+								". You have previously deleted it from your list!")
+						// We don't continue as it was manually removed as is still
+						// soft deleted. We don't want to re-add it (user should un-delete themselves).
+						continue
 					} else {
-						slog.Error("jellyfinSyncWatched: Movie failed to import.", "movie_name", v.Name, "movie_ids", v.ProviderIds, "user_id", userId)
-						job.AddJobError(jobId, userId, "movie could not be imported (failed when adding to watched list): "+v.Name)
+						slog.Error("jellyfinSyncWatched: Movie failed to import.",
+							"movie_name", v.Name,
+							"movie_ids", v.ProviderIds,
+							"user_id", userId,
+							"error", err)
+						job.AddJobError(
+							jobId,
+							userId,
+							"movie could not be imported (failed when adding to watched list): "+v.Name)
 					}
 				} else {
 					// 3. Add IMPORTED_ADDED_WATCHED_JF activity
@@ -210,18 +236,42 @@ func (s *SyncService) startJellyfinSync(
 				job.UpdateJobCurrentTask(jobId, userId, "syncing serie "+v.Name)
 
 				// 2. Imported watched series
-				w, err := s.wp.AddWatched(userId, domain.WatchedAddRequest{
-					Status:      entity.FINISHED,
-					ContentType: util.SupportedMediaShow,
-					TMDBID:      tmdbId,
-					WatchedDate: v.UserData.LastPlayedDate,
-				}, entity.IMPORTED_WATCHED_JF)
+				w, err := s.wp.AddWatched(
+					userId,
+					domain.WatchedAddRequest{
+						Status:      entity.FINISHED,
+						ContentType: util.SupportedMediaShow,
+						TMDBID:      tmdbId,
+						WatchedDate: v.UserData.LastPlayedDate,
+					}, domain.WatchedAddExtraProps{
+						ActivityType: entity.IMPORTED_WATCHED_JF,
+						DontRestore:  true,
+					})
 				if err != nil {
-					if err.Error() == "content already on watched list" {
-						slog.Info("jellyfinSyncWatched: Unique constraint hit.. content must already be on watch list.",
-							"series_name", v.Name, "series_ids", v.ProviderIds, "user_id", userId, "watched_id", w.ID)
+					if errors.Is(err, domain.ErrWatchedExists) {
+						slog.Info("jellyfinSyncWatched: Content already exists on list.",
+							"series_name", v.Name,
+							"series_ids", v.ProviderIds,
+							"user_id", userId,
+							"watched_id", w.ID)
+						// In this case, we allow continuing below to start syncing seasons/episodes
+					} else if errors.Is(err, domain.ErrWatchedExistsSoftDeleted) {
+						slog.Warn("jellyfinSyncWatched: Show exists on list soft deleted.")
+						job.AddJobError(
+							jobId,
+							userId,
+							"failed to add show "+
+								v.Name+
+								". You have previously deleted it from your list!")
+						// We don't continue as it was manually removed as is still
+						// soft deleted. We don't want to re-add it (user should un-delete themselves).
+						continue
 					} else {
-						slog.Error("jellyfinSyncWatched: Series failed to import.", "series_name", v.Name, "series_ids", v.ProviderIds, "user_id", userId)
+						slog.Error("jellyfinSyncWatched: Series failed to import.",
+							"series_name", v.Name,
+							"series_ids", v.ProviderIds,
+							"user_id", userId,
+							"error", err)
 						job.AddJobError(jobId, userId, "series could not be imported (failed when adding to watched list): "+v.Name)
 					}
 				} else {

--- a/server/feature/jellyfin/jellyfin_sync.go
+++ b/server/feature/jellyfin/jellyfin_sync.go
@@ -139,7 +139,8 @@ func (s *SyncService) startJellyfinSync(
 						ContentType: util.SupportedMediaMovie,
 						TMDBID:      tmdbId,
 						WatchedDate: v.UserData.LastPlayedDate,
-					}, domain.WatchedAddExtraProps{
+					},
+					domain.WatchedAddExtraProps{
 						ActivityType: entity.IMPORTED_WATCHED_JF,
 						DontRestore:  true,
 					})
@@ -243,7 +244,8 @@ func (s *SyncService) startJellyfinSync(
 						ContentType: util.SupportedMediaShow,
 						TMDBID:      tmdbId,
 						WatchedDate: v.UserData.LastPlayedDate,
-					}, domain.WatchedAddExtraProps{
+					},
+					domain.WatchedAddExtraProps{
 						ActivityType: entity.IMPORTED_WATCHED_JF,
 						DontRestore:  true,
 					})

--- a/server/feature/jellyfin/jellyfin_sync.go
+++ b/server/feature/jellyfin/jellyfin_sync.go
@@ -150,6 +150,8 @@ func (s *SyncService) startJellyfinSync(
 							"movie_ids", v.ProviderIds,
 							"user_id", userId)
 					} else if errors.Is(err, domain.ErrWatchedExistsSoftDeleted) {
+						// Entry was manually soft deleted by user at another point,
+						// we DontRestore these automatically.
 						slog.Warn("jellyfinSyncWatched: Movie exists on list soft deleted.")
 						job.AddJobError(
 							jobId,
@@ -157,8 +159,6 @@ func (s *SyncService) startJellyfinSync(
 							"failed to add movie "+
 								v.Name+
 								". You have previously deleted it from your list!")
-						// We don't continue as it was manually removed as is still
-						// soft deleted. We don't want to re-add it (user should un-delete themselves).
 						continue
 					} else {
 						slog.Error("jellyfinSyncWatched: Movie failed to import.",
@@ -256,6 +256,9 @@ func (s *SyncService) startJellyfinSync(
 							"watched_id", w.ID)
 						// In this case, we allow continuing below to start syncing seasons/episodes
 					} else if errors.Is(err, domain.ErrWatchedExistsSoftDeleted) {
+						// Entry was manually soft deleted by user at another point,
+						// we DontRestore these automatically. We also don't continue
+						// because eps/seasons cant be synced.
 						slog.Warn("jellyfinSyncWatched: Show exists on list soft deleted.")
 						job.AddJobError(
 							jobId,
@@ -263,8 +266,6 @@ func (s *SyncService) startJellyfinSync(
 							"failed to add show "+
 								v.Name+
 								". You have previously deleted it from your list!")
-						// We don't continue as it was manually removed as is still
-						// soft deleted. We don't want to re-add it (user should un-delete themselves).
 						continue
 					} else {
 						slog.Error("jellyfinSyncWatched: Series failed to import.",

--- a/server/feature/plex/plex_sync.go
+++ b/server/feature/plex/plex_sync.go
@@ -134,6 +134,8 @@ func (s *SyncService) startPlexSync(
 						continue
 					}
 					if errors.Is(err, domain.ErrWatchedExistsSoftDeleted) {
+						// Entry was manually soft deleted by user at another point,
+						// we DontRestore these automatically.
 						slog.Warn("plexSyncWatched: Movie exists on list soft deleted.")
 						job.AddJobError(
 							jobId,
@@ -141,8 +143,6 @@ func (s *SyncService) startPlexSync(
 							"failed to add movie "+
 								movie.Title+
 								". You have previously deleted it from your list!")
-						// We don't continue as it was manually removed as is still
-						// soft deleted. We don't want to re-add it (user should un-delete themselves).
 						continue
 					}
 					slog.Error("plexSyncWatched: Failed to add movie as watched", "error", err)
@@ -218,6 +218,9 @@ func (s *SyncService) startPlexSync(
 						slog.Info("plexSyncWatched: Show already exists on list.")
 						// In this case, we allow continuing below to start syncing seasons/episodes
 					} else if errors.Is(err, domain.ErrWatchedExistsSoftDeleted) {
+						// Entry was manually soft deleted by user at another point,
+						// we DontRestore these automatically. We also don't continue
+						// because eps/seasons cant be synced.
 						slog.Warn("plexSyncWatched: Show exists on list soft deleted.")
 						job.AddJobError(
 							jobId,
@@ -225,8 +228,6 @@ func (s *SyncService) startPlexSync(
 							"failed to add show "+
 								show.Title+
 								". You have previously deleted it from your list!")
-						// We don't continue as it was manually removed as is still
-						// soft deleted. We don't want to re-add it (user should un-delete themselves).
 						continue
 					} else {
 						slog.Error("plexSyncWatched: Failed to add show as watched", "error", err)

--- a/server/feature/plex/plex_sync.go
+++ b/server/feature/plex/plex_sync.go
@@ -20,7 +20,7 @@ type PlexSyncResponse struct {
 }
 
 type WatchedProvider interface {
-	AddWatched(userId uint, ar domain.WatchedAddRequest, at entity.ActivityType) (entity.Watched, error)
+	AddWatched(userId uint, ar domain.WatchedAddRequest, extraProps domain.WatchedAddExtraProps) (entity.Watched, error)
 }
 
 type WatchedSeasonProvider interface {
@@ -115,16 +115,34 @@ func (s *SyncService) startPlexSync(
 				}
 
 				lastViewedAt := time.Unix(movie.LastViewedAt, 0)
-				w, err := s.wp.AddWatched(userId, domain.WatchedAddRequest{
-					Status:      entity.FINISHED,
-					TMDBID:      tmdbId,
-					ContentType: util.SupportedMediaMovie,
-					Rating:      float64(movie.UserRating),
-					WatchedDate: lastViewedAt,
-				}, entity.IMPORTED_WATCHED_PLEX)
+				w, err := s.wp.AddWatched(
+					userId,
+					domain.WatchedAddRequest{
+						Status:      entity.FINISHED,
+						TMDBID:      tmdbId,
+						ContentType: util.SupportedMediaMovie,
+						Rating:      float64(movie.UserRating),
+						WatchedDate: lastViewedAt,
+					},
+					domain.WatchedAddExtraProps{
+						ActivityType: entity.IMPORTED_WATCHED_PLEX,
+						DontRestore:  true,
+					})
 				if err != nil {
-					if err.Error() == "content already on watched list" {
-						slog.Error("plexSyncWatched: unique constraint hit. movie must already be on watch list", "error", err)
+					if errors.Is(err, domain.ErrWatchedExists) {
+						slog.Info("plexSyncWatched: Movie already exists on list.")
+						continue
+					}
+					if errors.Is(err, domain.ErrWatchedExistsSoftDeleted) {
+						slog.Warn("plexSyncWatched: Movie exists on list soft deleted.")
+						job.AddJobError(
+							jobId,
+							userId,
+							"failed to add movie "+
+								movie.Title+
+								". You have previously deleted it from your list!")
+						// We don't continue as it was manually removed as is still
+						// soft deleted. We don't want to re-add it (user should un-delete themselves).
 						continue
 					}
 					slog.Error("plexSyncWatched: Failed to add movie as watched", "error", err)
@@ -182,16 +200,34 @@ func (s *SyncService) startPlexSync(
 				}
 
 				lastViewedAt := time.Unix(show.LastViewedAt, 0)
-				w, err := s.wp.AddWatched(userId, domain.WatchedAddRequest{
-					Status:      entity.FINISHED,
-					ContentType: util.SupportedMediaShow,
-					TMDBID:      tmdbId,
-					Rating:      float64(show.UserRating),
-					WatchedDate: lastViewedAt,
-				}, entity.IMPORTED_WATCHED_PLEX)
+				w, err := s.wp.AddWatched(
+					userId,
+					domain.WatchedAddRequest{
+						Status:      entity.FINISHED,
+						ContentType: util.SupportedMediaShow,
+						TMDBID:      tmdbId,
+						Rating:      float64(show.UserRating),
+						WatchedDate: lastViewedAt,
+					},
+					domain.WatchedAddExtraProps{
+						ActivityType: entity.IMPORTED_WATCHED_PLEX,
+						DontRestore:  true,
+					})
 				if err != nil {
-					if err.Error() == "content already on watched list" {
-						slog.Info("plexSyncWatched: unique constraint hit. show must already be on watch list", "error", err)
+					if errors.Is(err, domain.ErrWatchedExists) {
+						slog.Info("plexSyncWatched: Show already exists on list.")
+						// In this case, we allow continuing below to start syncing seasons/episodes
+					} else if errors.Is(err, domain.ErrWatchedExistsSoftDeleted) {
+						slog.Warn("plexSyncWatched: Show exists on list soft deleted.")
+						job.AddJobError(
+							jobId,
+							userId,
+							"failed to add show "+
+								show.Title+
+								". You have previously deleted it from your list!")
+						// We don't continue as it was manually removed as is still
+						// soft deleted. We don't want to re-add it (user should un-delete themselves).
+						continue
 					} else {
 						slog.Error("plexSyncWatched: Failed to add show as watched", "error", err)
 						job.AddJobError(jobId, userId, "failed to add show "+show.Title)

--- a/server/feature/tag/tag.go
+++ b/server/feature/tag/tag.go
@@ -84,7 +84,7 @@ func (s *Service) GetTagPage(
 	// This isn't great, but it has to be done, since we can't eliminate
 	// any for sort/filters here.
 	wids := new([]int)
-	res := s.db.Debug().
+	res := s.db.
 		Table("watched_tags").
 		Select("watched_id").
 		Where("tag_id = ?", tagId).

--- a/server/feature/watched/router.go
+++ b/server/feature/watched/router.go
@@ -120,7 +120,9 @@ func (r *Router) AddWatched(c *gin.Context) {
 	var ar domain.WatchedAddRequest
 	err := c.ShouldBindJSON(&ar)
 	if err == nil {
-		response, err := r.s.AddWatched(userId, ar, entity.ADDED_WATCHED)
+		response, err := r.s.AddWatched(userId, ar, domain.WatchedAddExtraProps{
+			ActivityType: entity.ADDED_WATCHED,
+		})
 		if err != nil {
 			c.JSON(http.StatusForbidden, router.ErrorResponse{Error: err.Error()})
 			return

--- a/server/feature/watched/watched.go
+++ b/server/feature/watched/watched.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strconv"
 
+	"github.com/sbondCo/Watcharr/database/dbmodel"
 	"github.com/sbondCo/Watcharr/database/entity"
 	"github.com/sbondCo/Watcharr/domain"
 	"github.com/sbondCo/Watcharr/feature/watched/addedtocontent"
@@ -341,11 +342,17 @@ func (s *Service) GetWatchedItemsBySupportedMediaIds(userId uint, c []addedtocon
 func (s *Service) AddWatched(
 	userId uint,
 	ar domain.WatchedAddRequest,
-	at entity.ActivityType,
+	extraProps domain.WatchedAddExtraProps,
 ) (entity.Watched, error) {
 	slog.Debug("Adding watched item",
 		"user_id", userId,
-		"add_request", ar)
+		"add_request", ar,
+		"extra_props", extraProps)
+
+	if extraProps.ActivityType == "" {
+		// We ALWAYS require the ActivityType to be provided by any caller.
+		return entity.Watched{}, errors.New("extraProp ActivityType not specified")
+	}
 
 	watched := entity.Watched{
 		UserID: userId,
@@ -422,11 +429,21 @@ func (s *Service) AddWatched(
 	// Create the entry in db.
 	res := s.db.Create(&watched)
 	if res.Error != nil {
-		if res.Error == gorm.ErrDuplicatedKey {
-			// Try to restore the entry if unique contraint hit.
-			if err := s.restoreWatched(userId, ar, &watched); err != nil {
+		if errors.Is(res.Error, gorm.ErrDuplicatedKey) {
+			// The record already exists.
+			// It could be soft deleted or not.
+			slog.Info("AddWatched: Creating row failed because of a unique key constraint violation.")
+			if err := s.restoreWatchedAfterDuplicatedKeyErr(
+				userId,
+				ar,
+				extraProps.DontRestore,
+				&watched,
+			); err != nil {
+				// Try to restore the entry if unique contraint hit.
 				slog.Error("AddWatched: Failed to restore existing watched entry.")
-				return entity.Watched{}, errors.New("failed when restoring existing entry")
+				// Returns watched too because handlers of certain errors
+				// may need it (and it's ID since we could have fetched it here)
+				return watched, err
 			}
 		} else {
 			slog.Error("AddWatched: Error adding watched to database", "error", res.Error.Error())
@@ -438,7 +455,7 @@ func (s *Service) AddWatched(
 	// Finally add activity
 	activityAddReq := domain.ActivityAddRequest{
 		WatchedID: watched.ID,
-		Type:      at,
+		Type:      extraProps.ActivityType,
 	}
 	if activityJson, err := json.Marshal(map[string]any{
 		"status": ar.Status,
@@ -461,12 +478,16 @@ func (s *Service) AddWatched(
 // Restore a watched entry that was soft deleted.
 // Currently used for AddWatched, when it realizes the entry may exist already
 // as a soft deleted record.
-func (s *Service) restoreWatched(
+//
+// NOTE: This function assumes it is being ran after a unique constraint
+// violation (like in AddWatched).
+func (s *Service) restoreWatchedAfterDuplicatedKeyErr(
 	userId uint,
 	ar domain.WatchedAddRequest,
+	dontRestore bool,
 	watchedOut *entity.Watched,
 ) error {
-	slog.Info("restoreWatched: Attempting to restore.",
+	slog.Info("restoreWatchedAfterDuplicatedKeyErr: Attempting to restore.",
 		"user_id", userId)
 
 	// Our base where statement to find the row we want to restore by unique
@@ -489,40 +510,60 @@ func (s *Service) restoreWatched(
 		return errors.New("no supported media ids in provided watched struct")
 	}
 
-	// Try to restore and update the possibly existing row.
-	res := s.db.Debug().Model(&entity.Watched{}).
+	// First we will try to get the record.
+	res := s.db.
+		Model(&entity.Watched{}).
 		Unscoped().
+		// Just loading activity now too so if we restore record,
+		// we can give the full activity in response.
+		Preload("Activity").
 		Where(&whereStmt).
-		Where("deleted_at IS NOT NULL").
+		Take(&watchedOut)
+	if res.Error != nil {
+		slog.Error("restoreWatchedAfterDuplicatedKeyErr: Select query failed!",
+			"error", res.Error)
+		return errors.New("errored checking for potential soft deleted record")
+	}
+	if watchedOut.ID == 0 {
+		return errors.New("didn't find an existing record")
+	}
+	if watchedOut.DeletedAt.Time.IsZero() {
+		// If it's not deleted, then it just exists..
+		return domain.ErrWatchedExists
+	} else if dontRestore {
+		// If we are told not to attempt a restore (eg by a sync-er).
+		return domain.ErrWatchedExistsSoftDeleted
+	}
+
+	// If we are here, we have a soft deleted record to restore:
+	res = s.db.
+		// Passing `&watchedOut` makes gorm do another query for inserting
+		// all existing rows into db, im not sure why... but just going to
+		// manually pass primary key in.
+		Model(&entity.Watched{
+			GormModel: dbmodel.GormModel{ID: watchedOut.ID},
+		}).
+		Unscoped().
 		Updates(map[string]any{
 			"status":     ar.Status,
 			"rating":     ar.Rating,
 			"thoughts":   ar.Thoughts,
 			"deleted_at": nil,
 		})
-	if res.Error != nil {
-		slog.Error("restoreWatched: Checking for record failed!",
-			"error", res.Error)
-		return errors.New("errored checking for soft deleted record")
+	if res.Error != nil || res.RowsAffected == 0 {
+		slog.Error("restoreWatchedAfterDuplicatedKeyErr: Updating record failed!",
+			"error", res.Error,
+			"rows_affected", res.RowsAffected)
+		return errors.New("failed to update record")
 	}
-	if res.RowsAffected == 0 {
-		slog.Error("restoreWatched: Nothing was updated. The row may already exist un-deleted.")
-		return errors.New("didnt find an entry to restore")
-	}
-	slog.Info("restoreWatched: Restored record.",
-		"user_id", userId)
+	// We have updated the row, update our struct now.
+	watchedOut.Status = ar.Status
+	watchedOut.Rating = ar.Rating
+	watchedOut.Thoughts = ar.Thoughts
+	watchedOut.DeletedAt = gorm.DeletedAt{}
 
-	// Restore query above succeeded so now lets get all data needed and return.
-	res = s.db.Debug().Model(&entity.Watched{}).
-		Unscoped().
-		Preload("Activity").
-		Where(&whereStmt).
-		Take(&watchedOut)
-	if res.Error != nil {
-		slog.Error("restoreWatched: Getting updated record failed!",
-			"error", res.Error)
-		return errors.New("errored while trying to get updated record")
-	}
+	slog.Info("restoreWatchedAfterDuplicatedKeyErr: Updated record.",
+		"user_id", userId)
 
 	return nil
 }


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

Fixes #1028
