### PR TITLE
Implement ownership verification for AddActivity (minor)

### DIFF
--- a/server/feature/activity/activity.go
+++ b/server/feature/activity/activity.go
@@ -33,9 +33,9 @@ func (s *Service) AddActivity(userId uint, ar domain.ActivityAddRequest) (entity
 	if ar.WatchedID == 0 {
 		return entity.Activity{}, errors.New("watchedId must be set to add an activity")
 	}
-	// Verify watched entry belongs to the calling user.
+	// Verify watched entry belongs to the calling user, unscoped so soft-deleted entries still pass.
 	var count int64
-	if res := s.db.Model(&entity.Watched{}).Where("id = ? AND user_id = ?", ar.WatchedID, userId).Count(&count); res.Error != nil {
+	if res := s.db.Unscoped().Model(&entity.Watched{}).Where("id = ? AND user_id = ?", ar.WatchedID, userId).Count(&count); res.Error != nil {
 		slog.Error("AddActivity: failed to verify watched ownership", "error", res.Error)
 		return entity.Activity{}, errors.New("failed to verify watched entry")
 	}

--- a/server/feature/activity/activity.go
+++ b/server/feature/activity/activity.go
@@ -33,6 +33,16 @@ func (s *Service) AddActivity(userId uint, ar domain.ActivityAddRequest) (entity
 	if ar.WatchedID == 0 {
 		return entity.Activity{}, errors.New("watchedId must be set to add an activity")
 	}
+	// Verify watched entry belongs to the calling user.
+	var count int64
+	if res := s.db.Model(&entity.Watched{}).Where("id = ? AND user_id = ?", ar.WatchedID, userId).Count(&count); res.Error != nil {
+		slog.Error("AddActivity: failed to verify watched ownership", "error", res.Error)
+		return entity.Activity{}, errors.New("failed to verify watched entry")
+	}
+	if count == 0 {
+		slog.Warn("AddActivity: user attempted to add activity for watched entry they do not own", "user_id", userId, "watched_id", ar.WatchedID)
+		return entity.Activity{}, errors.New("watched entry does not exist")
+	}
 	activity := entity.Activity{UserID: userId, WatchedID: ar.WatchedID, Type: ar.Type, Data: ar.Data, CustomDate: ar.CustomDate}
 	res := s.db.Create(&activity)
 	if res.Error != nil {


### PR DESCRIPTION
### Changes made

Added verification for watched entry ownership before adding an activity.

Needs to be tested if this gets added, this is super minor since and really the only thing they can do is just add a bunch of junk other users but this is self hosted so barely doubt this would ever even occur.