### PR TITLE
feat: show spoilers for finished episodes

### DIFF
--- a/src/lib/season/SeasonsListEpisode.svelte
+++ b/src/lib/season/SeasonsListEpisode.svelte
@@ -29,7 +29,7 @@
 	const SHOW_SPOILER_FOR_STATUS: WatchedStatus = "FINISHED";
 	let hideSpoilers: boolean = $state(!!store?.userSettings?.hideSpoilers && watchedEpisode?.status !== SHOW_SPOILER_FOR_STATUS);
 
-	function handleStatusClick(type: WatchedStatus | "DELETE") {
+	async function handleStatusClick(type: WatchedStatus | "DELETE") {
 		if (!watchedItem) {
 			console.error("SeasonListEpisode: handleStatusClick: No watched item.");
 			return;
@@ -47,12 +47,16 @@
 				});
 				return;
 			}
-			removeWatchedEpisode(watchedItem, ws.id);
+			await removeWatchedEpisode(watchedItem, ws.id);
+			episodeStatus = undefined;
+			hideSpoilers = !!store?.userSettings?.hideSpoilers;
 			return;
 		}
-		updateWatchedEpisode(watchedItem, ep.season_number, ep.episode_number, {
+		await updateWatchedEpisode(watchedItem, ep.season_number, ep.episode_number, {
 			status: type,
 		});
+		episodeStatus = type;
+		hideSpoilers = !!store?.userSettings?.hideSpoilers && episodeStatus !== SHOW_SPOILER_FOR_STATUS;
 	}
 
 	function handleStarClick(rating: number) {
@@ -114,7 +118,7 @@
 			{/if}
 			<div class="status">
 				<PosterStatus
-					status={watchedEpisode?.status}
+					status={episodeStatus}
 					btnTooltip={`Episode ${ep.episode_number} Status`}
 					handleStatusClick={(t) => handleStatusClick(t)}
 					direction="bot"
@@ -246,7 +250,7 @@
 			justify-content: center;
 			gap: 8px;
 			position: absolute;
-			width: 100%;
+			width: calc(100% - 45px);
 			height: 100%;
 			font-weight: bolder;
 			font-size: 20px;

--- a/src/lib/season/SeasonsListEpisode.svelte
+++ b/src/lib/season/SeasonsListEpisode.svelte
@@ -24,10 +24,13 @@
 			s.episodeNumber === ep.episode_number,
 	);
 	let episodeStatus = $state(watchedEpisode?.status);
-	
+
 	// Show episode spoilers when the user finished watching
 	const SHOW_SPOILER_FOR_STATUS: WatchedStatus = "FINISHED";
-	let hideSpoilers: boolean = $state(!!store?.userSettings?.hideSpoilers && watchedEpisode?.status !== SHOW_SPOILER_FOR_STATUS);
+	let hideSpoilers: boolean = $state(
+		!!store?.userSettings?.hideSpoilers &&
+			watchedEpisode?.status !== SHOW_SPOILER_FOR_STATUS,
+	);
 
 	async function handleStatusClick(type: WatchedStatus | "DELETE") {
 		if (!watchedItem) {
@@ -52,11 +55,18 @@
 			hideSpoilers = !!store?.userSettings?.hideSpoilers;
 			return;
 		}
-		await updateWatchedEpisode(watchedItem, ep.season_number, ep.episode_number, {
-			status: type,
-		});
+		await updateWatchedEpisode(
+			watchedItem,
+			ep.season_number,
+			ep.episode_number,
+			{
+				status: type,
+			},
+		);
 		episodeStatus = type;
-		hideSpoilers = !!store?.userSettings?.hideSpoilers && episodeStatus !== SHOW_SPOILER_FOR_STATUS;
+		hideSpoilers =
+			!!store?.userSettings?.hideSpoilers &&
+			episodeStatus !== SHOW_SPOILER_FOR_STATUS;
 	}
 
 	function handleStarClick(rating: number) {

--- a/src/lib/season/SeasonsListEpisode.svelte
+++ b/src/lib/season/SeasonsListEpisode.svelte
@@ -18,7 +18,16 @@
 
 	let { ep, watchedItem }: Props = $props();
 
-	let isHidden: boolean = $state(!!store?.userSettings?.hideSpoilers);
+	const watchedEpisode = watchedItem?.watchedEpisodes?.find(
+		(s) =>
+			s.seasonNumber === ep.season_number &&
+			s.episodeNumber === ep.episode_number,
+	);
+	let episodeStatus = $state(watchedEpisode?.status);
+	
+	// Show episode spoilers when the user finished watching
+	const SHOW_SPOILER_FOR_STATUS: WatchedStatus = "FINISHED";
+	let hideSpoilers: boolean = $state(!!store?.userSettings?.hideSpoilers && watchedEpisode?.status !== SHOW_SPOILER_FOR_STATUS);
 
 	function handleStatusClick(type: WatchedStatus | "DELETE") {
 		if (!watchedItem) {
@@ -57,7 +66,7 @@
 	}
 </script>
 
-<li class={isHidden ? "dont-spoil" : ""}>
+<li class={hideSpoilers ? "dont-spoil" : ""}>
 	{#if ep.still_path}
 		<img
 			src={`https://www.themoviedb.org/t/p/w227_and_h127_bestv2/${ep.still_path}`}
@@ -90,25 +99,22 @@
 		<span class="overview">{ep.overview}</span>
 	</div>
 	{#if watchedItem}
-		{@const we = watchedItem.watchedEpisodes?.find(
-			(s) =>
-				s.seasonNumber === ep.season_number &&
-				s.episodeNumber === ep.episode_number,
-		)}
 		<div class="status-rating-ctr">
-			<div class="rating" style={"width: 45px"}>
-				<PosterRating
-					rating={we?.rating}
-					btnTooltip={`Episode ${ep.episode_number} Rating`}
-					handleStarClick={(r) => handleStarClick(r)}
-					minimal={true}
-					direction="bot"
-					hideStarWhenRated
-				/>
-			</div>
+			{#if !hideSpoilers}
+				<div class="rating" style={"width: 45px"}>
+					<PosterRating
+						rating={watchedEpisode?.rating}
+						btnTooltip={`Episode ${ep.episode_number} Rating`}
+						handleStarClick={(r) => handleStarClick(r)}
+						minimal={true}
+						direction="bot"
+						hideStarWhenRated
+					/>
+				</div>
+			{/if}
 			<div class="status">
 				<PosterStatus
-					status={we?.status}
+					status={watchedEpisode?.status}
 					btnTooltip={`Episode ${ep.episode_number} Status`}
 					handleStatusClick={(t) => handleStatusClick(t)}
 					direction="bot"
@@ -118,8 +124,8 @@
 			</div>
 		</div>
 	{/if}
-	{#if isHidden}
-		<button class="plain spoiler-text" onclick={() => (isHidden = false)}>
+	{#if hideSpoilers}
+		<button class="plain spoiler-text" onclick={() => (hideSpoilers = false)}>
 			<Icon i="eye-closed" wh={34} />
 			<span>Click To Reveal</span>
 		</button>

--- a/src/lib/season/SeasonsListEpisode.svelte
+++ b/src/lib/season/SeasonsListEpisode.svelte
@@ -104,18 +104,16 @@
 	</div>
 	{#if watchedItem}
 		<div class="status-rating-ctr">
-			{#if !hideSpoilers}
-				<div class="rating" style={"width: 45px"}>
-					<PosterRating
-						rating={watchedEpisode?.rating}
-						btnTooltip={`Episode ${ep.episode_number} Rating`}
-						handleStarClick={(r) => handleStarClick(r)}
-						minimal={true}
-						direction="bot"
-						hideStarWhenRated
-					/>
-				</div>
-			{/if}
+			<div class="rating" style={"width: 45px"}>
+				<PosterRating
+					rating={watchedEpisode?.rating}
+					btnTooltip={`Episode ${ep.episode_number} Rating`}
+					handleStarClick={(r) => handleStarClick(r)}
+					minimal={true}
+					direction="bot"
+					hideStarWhenRated
+				/>
+			</div>
 			<div class="status">
 				<PosterStatus
 					status={episodeStatus}
@@ -285,7 +283,6 @@
 
 		&.dont-spoil {
 			.episode-name,
-			.rating,
 			.overview {
 				filter: blur(4px);
 			}


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

### Changes made

- always display spoilers for finished episodes
- ~~only display the rating button when the spoiler overlay is removed~~
  allow users to rate episodes regardless of spoiler state or episode status[^1]
- let users change the episode status when the spoiler overlay is visible

<!-- Describe changes made here. If changes are visual a screenshot could be useful! -->
[^1]: I'm not sure what the expected behavior here is supposed to be, I changed this so it behaves similar to how movies currently work.