### PR TITLE
feat: "Up Next" row on the overview (next unwatched episode per show)

### DIFF
--- a/server/feature/watched/router.go
+++ b/server/feature/watched/router.go
@@ -36,6 +36,7 @@ func (r *Router) AddRoutes() {
 	watched := r.br.Router.Group("/watched").Use(authmiddleware.AuthRequired(nil, r.br.Cfg))
 
 	watched.GET("", router.PaginatedRequest(false), r.GetWatchedList)
+	watched.GET("/upnext", r.GetUpNext)
 	watched.GET(":id/:username", router.PaginatedRequest(true), r.GetPublicWatchedList)
 	watched.POST("", r.AddWatched)
 	watched.PUT(":id", r.UpdateWatched)
@@ -43,6 +44,17 @@ func (r *Router) AddRoutes() {
 	// TODO Move add/delete watched from tag to the `tag` package (the service code is there so the route may as well be under there, also avoids a circular dep).
 	watched.POST(":id/tag/:tagId", r.AddWatchedToTag)
 	watched.DELETE(":id/tag/:tagId", r.DeleteWatchedFromTag)
+}
+
+// Get the "Up Next" list: next unwatched aired episode per in-progress show.
+func (r *Router) GetUpNext(c *gin.Context) {
+	userId := c.MustGet("userId").(uint)
+	items, err := r.s.UpNext(userId)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, router.ErrorResponse{Error: "failed to get up next list"})
+		return
+	}
+	c.JSON(http.StatusOK, items)
 }
 
 // Get our (logged in user) watched list.

--- a/server/feature/watched/router.go
+++ b/server/feature/watched/router.go
@@ -49,7 +49,16 @@ func (r *Router) AddRoutes() {
 // Get the "Up Next" list: next unwatched aired episode per in-progress show.
 func (r *Router) GetUpNext(c *gin.Context) {
 	userId := c.MustGet("userId").(uint)
-	items, err := r.s.UpNext(userId)
+	wpr := domain.WatchedGetPageRequest{
+		// Defaults, mirroring the watched list.
+		Sort:    domain.WatchedSortDateAdded,
+		SortDir: domain.WatchedSortDirAsc,
+	}
+	if err := c.ShouldBind(&wpr); err != nil {
+		c.JSON(http.StatusBadRequest, router.ErrorResponse{Error: "failed to get request parameters"})
+		return
+	}
+	items, err := r.s.UpNext(userId, wpr)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, router.ErrorResponse{Error: "failed to get up next list"})
 		return

--- a/server/feature/watched/watched.go
+++ b/server/feature/watched/watched.go
@@ -10,12 +10,16 @@ import (
 	"github.com/sbondCo/Watcharr/database/entity"
 	"github.com/sbondCo/Watcharr/domain"
 	"github.com/sbondCo/Watcharr/feature/watched/addedtocontent"
+	"github.com/sbondCo/Watcharr/media/tmdb"
 	"github.com/sbondCo/Watcharr/util"
 	"gorm.io/gorm"
 )
 
 type ContentProvider interface {
 	GetOrCacheContent(contentType entity.ContentType, tmdbId int) (entity.Content, error)
+	// SeasonDetails returns a season's episodes (with air dates) from TMDB (cached).
+	// Used by the "Up Next" feature to find the next unwatched episode.
+	SeasonDetails(tvId string, seasonNumber string) (tmdb.TMDBSeasonDetails, error)
 }
 
 type GameProvider interface {

--- a/server/feature/watched/watched_upnext.go
+++ b/server/feature/watched/watched_upnext.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/sbondCo/Watcharr/database/entity"
+	"github.com/sbondCo/Watcharr/domain"
 )
 
 // UpNextItem describes the next unwatched episode of an in-progress show,
@@ -31,13 +32,18 @@ type UpNextItem struct {
 // TV broadcast schedule, which does not reflect streaming/replay availability
 // (a fully-streamable show can still have "future" broadcast dates). So we
 // simply offer the next episode that exists and hasn't been watched.
-func (s *Service) UpNext(userId uint) ([]UpNextItem, error) {
+func (s *Service) UpNext(userId uint, wpr domain.WatchedGetPageRequest) ([]UpNextItem, error) {
 	var watched []entity.Watched
 	res := s.db.
 		Joins("Content").
+		// Game is joined only so the shared sort scope (which references Game
+		// columns for some sorts) resolves; UpNext is shows-only so it's null.
+		Joins("Game").
 		Preload("WatchedEpisodes").
 		Where("watcheds.user_id = ? AND Content.type = ? AND watcheds.status = ?",
 			userId, entity.SHOW, entity.WATCHING).
+		// Apply the same sort as the watched list so Up Next matches its order.
+		Scopes(watchedRefineSort(wpr, userId)).
 		Find(&watched)
 	if res.Error != nil {
 		slog.Error("UpNext: query failed", "error", res.Error)

--- a/server/feature/watched/watched_upnext.go
+++ b/server/feature/watched/watched_upnext.go
@@ -1,0 +1,107 @@
+package watched
+
+import (
+	"log/slog"
+	"sort"
+	"strconv"
+
+	"github.com/sbondCo/Watcharr/database/entity"
+)
+
+// UpNextItem describes the next unwatched episode of an in-progress show,
+// for the "Up Next" row on the overview page.
+type UpNextItem struct {
+	WatchedID     uint   `json:"watchedId"`
+	TmdbID        int    `json:"tmdbId"`
+	ShowTitle     string `json:"showTitle"`
+	PosterPath    string `json:"posterPath"`
+	SeasonNumber  int    `json:"seasonNumber"`
+	EpisodeNumber int    `json:"episodeNumber"`
+	EpisodeName   string `json:"episodeName"`
+	StillPath     string `json:"stillPath"`
+	AirDate       string `json:"airDate"`
+}
+
+// UpNext returns, for each show the user is currently WATCHING, the next
+// unwatched episode. Shows that are fully watched are omitted.
+//
+// Note: we deliberately do NOT filter on TMDB air_date. TMDB's air_date is the
+// TV broadcast schedule, which does not reflect streaming/replay availability
+// (a fully-streamable show can still have "future" broadcast dates). So we
+// simply offer the next episode that exists and hasn't been watched.
+func (s *Service) UpNext(userId uint) ([]UpNextItem, error) {
+	var watched []entity.Watched
+	res := s.db.
+		Joins("Content").
+		Preload("WatchedEpisodes").
+		Where("watcheds.user_id = ? AND Content.type = ? AND watcheds.status = ?",
+			userId, entity.SHOW, entity.WATCHING).
+		Find(&watched)
+	if res.Error != nil {
+		slog.Error("UpNext: query failed", "error", res.Error)
+		return nil, res.Error
+	}
+
+	items := []UpNextItem{}
+	for i := range watched {
+		if item, ok := s.nextEpisodeFor(&watched[i]); ok {
+			items = append(items, item)
+		}
+	}
+	return items, nil
+}
+
+// nextEpisodeFor computes the next unwatched episode for one show. It scans
+// seasons starting from the highest season the user has already touched
+// (episodes are usually watched contiguously), fetching season details from
+// TMDB (cached) only as needed.
+func (s *Service) nextEpisodeFor(w *entity.Watched) (UpNextItem, bool) {
+	if w.Content == nil {
+		return UpNextItem{}, false
+	}
+	// Set of already-watched (season, episode).
+	seen := make(map[[2]int]bool, len(w.WatchedEpisodes))
+	maxSeason := 1
+	for _, we := range w.WatchedEpisodes {
+		seen[[2]int{we.SeasonNumber, we.EpisodeNumber}] = true
+		if we.SeasonNumber > maxSeason {
+			maxSeason = we.SeasonNumber
+		}
+	}
+
+	totalSeasons := int(w.Content.NumberOfSeasons)
+	if totalSeasons < maxSeason {
+		totalSeasons = maxSeason
+	}
+	tvId := strconv.Itoa(w.Content.TmdbID)
+
+	for season := maxSeason; season <= totalSeasons; season++ {
+		if season <= 0 { // skip specials (season 0)
+			continue
+		}
+		sd, err := s.cp.SeasonDetails(tvId, strconv.Itoa(season))
+		if err != nil {
+			slog.Warn("UpNext: season details failed", "tmdbId", w.Content.TmdbID, "season", season, "error", err)
+			continue
+		}
+		eps := sd.Episodes
+		sort.Slice(eps, func(a, b int) bool { return eps[a].EpisodeNumber < eps[b].EpisodeNumber })
+		for _, ep := range eps {
+			if seen[[2]int{ep.SeasonNumber, ep.EpisodeNumber}] {
+				continue
+			}
+			return UpNextItem{
+				WatchedID:     w.ID,
+				TmdbID:        w.Content.TmdbID,
+				ShowTitle:     w.Content.Title,
+				PosterPath:    w.Content.PosterPath,
+				SeasonNumber:  ep.SeasonNumber,
+				EpisodeNumber: ep.EpisodeNumber,
+				EpisodeName:   ep.Name,
+				StillPath:     ep.StillPath,
+				AirDate:       ep.AirDate,
+			}, true
+		}
+	}
+	return UpNextItem{}, false
+}

--- a/server/feature/watched/watched_upnext.go
+++ b/server/feature/watched/watched_upnext.go
@@ -17,9 +17,11 @@ type UpNextItem struct {
 	PosterPath    string `json:"posterPath"`
 	SeasonNumber  int    `json:"seasonNumber"`
 	EpisodeNumber int    `json:"episodeNumber"`
-	EpisodeName   string `json:"episodeName"`
-	StillPath     string `json:"stillPath"`
-	AirDate       string `json:"airDate"`
+	// Total number of episodes in that season (for a "S6.E2/12" style display).
+	SeasonEpisodeCount int    `json:"seasonEpisodeCount"`
+	EpisodeName        string `json:"episodeName"`
+	StillPath          string `json:"stillPath"`
+	AirDate            string `json:"airDate"`
 }
 
 // UpNext returns, for each show the user is currently WATCHING, the next
@@ -91,15 +93,16 @@ func (s *Service) nextEpisodeFor(w *entity.Watched) (UpNextItem, bool) {
 				continue
 			}
 			return UpNextItem{
-				WatchedID:     w.ID,
-				TmdbID:        w.Content.TmdbID,
-				ShowTitle:     w.Content.Title,
-				PosterPath:    w.Content.PosterPath,
-				SeasonNumber:  ep.SeasonNumber,
-				EpisodeNumber: ep.EpisodeNumber,
-				EpisodeName:   ep.Name,
-				StillPath:     ep.StillPath,
-				AirDate:       ep.AirDate,
+				WatchedID:          w.ID,
+				TmdbID:             w.Content.TmdbID,
+				ShowTitle:          w.Content.Title,
+				PosterPath:         w.Content.PosterPath,
+				SeasonNumber:       ep.SeasonNumber,
+				EpisodeNumber:      ep.EpisodeNumber,
+				SeasonEpisodeCount: len(eps),
+				EpisodeName:        ep.Name,
+				StillPath:          ep.StillPath,
+				AirDate:            ep.AirDate,
 			}, true
 		}
 	}

--- a/src/lib/UpNext.svelte
+++ b/src/lib/UpNext.svelte
@@ -13,6 +13,7 @@
 		posterPath: string;
 		seasonNumber: number;
 		episodeNumber: number;
+		seasonEpisodeCount: number;
 		episodeName: string;
 		stillPath: string;
 		airDate: string;
@@ -56,6 +57,22 @@
 		}
 	}
 
+	async function dropShow(item: UpNextItem) {
+		if (!confirm(`Drop "${item.showTitle}"? It will leave your Up Next list.`)) return;
+		busyId = item.watchedId;
+		const nid = notify({ text: `Dropping ${item.showTitle}`, type: "loading" });
+		try {
+			await axios.put(`/watched/${item.watchedId}`, { status: "DROPPED" });
+			notify({ id: nid, text: "Dropped", type: "success" });
+			await load(); // the show leaves the Up Next row (no longer "Watching")
+		} catch (err) {
+			console.error("UpNext: dropShow failed", err);
+			notify({ id: nid, text: "Failed to drop!", type: "error" });
+		} finally {
+			busyId = undefined;
+		}
+	}
+
 	function img(item: UpNextItem) {
 		const p = item.stillPath || item.posterPath;
 		return p ? `https://image.tmdb.org/t/p/w300${p}` : "";
@@ -82,9 +99,9 @@
 				<div class="meta">
 					<span class="show">{item.showTitle}</span>
 					<span class="ep">
-						S{item.seasonNumber}E{item.episodeNumber}{item.episodeName
-							? ` · ${item.episodeName}`
-							: ""}
+						S{item.seasonNumber}.E{item.episodeNumber}{item.seasonEpisodeCount
+							? `/${item.seasonEpisodeCount}`
+							: ""}{item.episodeName ? ` · ${item.episodeName}` : ""}
 					</span>
 					{#if item.airDate}
 						{@const future = new Date(item.airDate) > new Date()}
@@ -93,13 +110,23 @@
 						</span>
 					{/if}
 				</div>
-				<button
-					class="mark"
-					disabled={busyId === item.watchedId}
-					onclick={() => markWatched(item)}
-				>
-					✓ Watched
-				</button>
+				<div class="actions">
+					<button
+						class="mark"
+						disabled={busyId === item.watchedId}
+						onclick={() => markWatched(item)}
+					>
+						✓ Watched
+					</button>
+					<button
+						class="drop"
+						disabled={busyId === item.watchedId}
+						onclick={() => dropShow(item)}
+						title="Drop this show (abandon)"
+					>
+						Drop
+					</button>
+				</div>
 			</li>
 		{/each}
 	</HorizontalList>
@@ -162,11 +189,23 @@
 		font-weight: 600;
 		color: #e0a13c;
 	}
+	.actions {
+		display: flex;
+		gap: 6px;
+	}
 	.mark {
+		flex: 1;
 		display: flex;
 		align-items: center;
 		gap: 4px;
 		justify-content: center;
 		cursor: pointer;
+	}
+	.drop {
+		cursor: pointer;
+		opacity: 0.7;
+	}
+	.drop:hover {
+		opacity: 1;
 	}
 </style>

--- a/src/lib/UpNext.svelte
+++ b/src/lib/UpNext.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import axios from "axios";
-	import { onMount } from "svelte";
 	import { goto } from "$app/navigation";
 	import { notify } from "@/lib/util/notify";
 	import HorizontalList from "@/lib/HorizontalList.svelte";
 	import Icon from "@/lib/Icon.svelte";
+	import { store } from "@/store.svelte";
 
 	interface UpNextItem {
 		watchedId: number;
@@ -25,7 +25,14 @@
 
 	async function load() {
 		try {
-			const r = await axios.get<UpNextItem[]>("/watched/upnext");
+			// Pass the same sort as the watched list so Up Next matches its order.
+			const qp = store.sortAndFiltersForQueryParams as {
+				sort?: string;
+				sortDir?: string;
+			};
+			const r = await axios.get<UpNextItem[]>("/watched/upnext", {
+				params: { sort: qp?.sort, sortDir: qp?.sortDir },
+			});
 			items = r.data ?? [];
 		} catch (err) {
 			console.error("UpNext: load failed", err);
@@ -77,7 +84,12 @@
 		return p ? `https://image.tmdb.org/t/p/w300${p}` : "";
 	}
 
-	onMount(load);
+	// Load on mount and whenever the sort changes, so Up Next stays in the
+	// same order as the watched list.
+	$effect(() => {
+		void store.activeSort;
+		load();
+	});
 </script>
 
 {#if !loading && items.length > 0}

--- a/src/lib/UpNext.svelte
+++ b/src/lib/UpNext.svelte
@@ -58,7 +58,6 @@
 	}
 
 	async function dropShow(item: UpNextItem) {
-		if (!confirm(`Drop "${item.showTitle}"? It will leave your Up Next list.`)) return;
 		busyId = item.watchedId;
 		const nid = notify({ text: `Dropping ${item.showTitle}`, type: "loading" });
 		try {
@@ -194,7 +193,7 @@
 		gap: 6px;
 	}
 	.mark {
-		flex: 1;
+		flex: 4 1 0;
 		display: flex;
 		align-items: center;
 		gap: 4px;
@@ -202,6 +201,7 @@
 		cursor: pointer;
 	}
 	.drop {
+		flex: 1 1 0;
 		cursor: pointer;
 		opacity: 0.7;
 	}

--- a/src/lib/UpNext.svelte
+++ b/src/lib/UpNext.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+	import axios from "axios";
+	import { onMount } from "svelte";
+	import { goto } from "$app/navigation";
+	import { notify } from "@/lib/util/notify";
+	import HorizontalList from "@/lib/HorizontalList.svelte";
+	import Icon from "@/lib/Icon.svelte";
+
+	interface UpNextItem {
+		watchedId: number;
+		tmdbId: number;
+		showTitle: string;
+		posterPath: string;
+		seasonNumber: number;
+		episodeNumber: number;
+		episodeName: string;
+		stillPath: string;
+		airDate: string;
+	}
+
+	let items = $state<UpNextItem[]>([]);
+	let loading = $state(true);
+	let busyId = $state<number | undefined>(undefined);
+
+	async function load() {
+		try {
+			const r = await axios.get<UpNextItem[]>("/watched/upnext");
+			items = r.data ?? [];
+		} catch (err) {
+			console.error("UpNext: load failed", err);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function markWatched(item: UpNextItem) {
+		busyId = item.watchedId;
+		const nid = notify({
+			text: `Marking ${item.showTitle} S${item.seasonNumber}E${item.episodeNumber}`,
+			type: "loading",
+		});
+		try {
+			await axios.post("/watched/episode", {
+				watchedId: item.watchedId,
+				seasonNumber: item.seasonNumber,
+				episodeNumber: item.episodeNumber,
+				status: "FINISHED",
+			});
+			notify({ id: nid, text: "Marked as watched!", type: "success" });
+			await load(); // refresh: the card advances to the next episode (or drops off)
+		} catch (err) {
+			console.error("UpNext: markWatched failed", err);
+			notify({ id: nid, text: "Failed to mark as watched!", type: "error" });
+		} finally {
+			busyId = undefined;
+		}
+	}
+
+	function img(item: UpNextItem) {
+		const p = item.stillPath || item.posterPath;
+		return p ? `https://image.tmdb.org/t/p/w300${p}` : "";
+	}
+
+	onMount(load);
+</script>
+
+{#if !loading && items.length > 0}
+	<HorizontalList title="Up Next">
+		{#each items as item (item.watchedId)}
+			<li class="up-next-card">
+				<button
+					class="thumb"
+					onclick={() => goto(`/tv/${item.tmdbId}`)}
+					title={item.showTitle}
+				>
+					{#if img(item)}
+						<img src={img(item)} alt="" />
+					{:else}
+						<div class="noimg"><Icon i="reel" wh={30} /></div>
+					{/if}
+				</button>
+				<div class="meta">
+					<span class="show">{item.showTitle}</span>
+					<span class="ep">
+						S{item.seasonNumber}E{item.episodeNumber}{item.episodeName
+							? ` · ${item.episodeName}`
+							: ""}
+					</span>
+					{#if item.airDate}
+						{@const future = new Date(item.airDate) > new Date()}
+						<span class="air" class:future title="TV broadcast date">
+							{future ? "📺 Airs " : ""}{new Date(item.airDate).toLocaleDateString()}
+						</span>
+					{/if}
+				</div>
+				<button
+					class="mark"
+					disabled={busyId === item.watchedId}
+					onclick={() => markWatched(item)}
+				>
+					✓ Watched
+				</button>
+			</li>
+		{/each}
+	</HorizontalList>
+{/if}
+
+<style lang="scss">
+	.up-next-card {
+		display: flex;
+		flex-flow: column;
+		width: 220px;
+		min-width: 220px;
+		gap: 6px;
+	}
+	.thumb {
+		padding: 0;
+		border: none;
+		background: none;
+		cursor: pointer;
+		width: 100%;
+		aspect-ratio: 16 / 9;
+		border-radius: 8px;
+		overflow: hidden;
+	}
+	.thumb img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+	.noimg {
+		width: 100%;
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.2);
+	}
+	.meta {
+		display: flex;
+		flex-flow: column;
+	}
+	.show {
+		font-weight: bold;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.ep {
+		font-size: 12px;
+		opacity: 0.8;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.air {
+		font-size: 11px;
+		opacity: 0.55;
+	}
+	.air.future {
+		opacity: 1;
+		font-weight: 600;
+		color: #e0a13c;
+	}
+	.mark {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		justify-content: center;
+		cursor: pointer;
+	}
+</style>

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -5,6 +5,7 @@
 	import Poster from "@/lib/poster/Poster.svelte";
 	import PosterList from "@/lib/poster/PosterList.svelte";
 	import Spinner from "@/lib/Spinner.svelte";
+	import UpNext from "@/lib/UpNext.svelte";
 	import infScroll from "@/lib/util/infScroll";
 	import paginatedLoader from "@/lib/util/paginatedLoader.svelte";
 	import { clearActiveFilters, store } from "@/store.svelte";
@@ -81,6 +82,8 @@
 	{JSON.stringify(store.activeFilters)} <b>queryp:</b>
 	{JSON.stringify(store.sortAndFiltersForQueryParams)}</span
 > -->
+
+<UpNext />
 
 <PosterList>
 	{#if dataLoader.state.data?.length > 0}


### PR DESCRIPTION
## What
Adds an "Up Next" row at the top of the overview: for each in-progress (Watching)
show, it shows the next unwatched episode with a quick "✓ Watched" action that
marks it and advances the card to the following episode.

Relates to #1008 (the unwatched "to watch" part) and #903 (quick-mark next episode).

## How
- **Backend**: new `GET /watched/upnext` returning the next unwatched episode per
  Watching show (`server/feature/watched/watched_upnext.go`); scans seasons from
  the highest watched one using cached TMDB season details. `ContentProvider` gains
  `SeasonDetails`.
- **Frontend**: `UpNext.svelte` (a `HorizontalList`) on the overview; "✓ Watched"
  reuses `POST /watched/episode` then refreshes.

## Design note
Episodes are offered regardless of TMDB `air_date`: that date is the TV broadcast
schedule and doesn't reflect streaming/replay availability (a fully streamable show
can still have "future" broadcast dates). The broadcast date is shown on each card,
flagging not-yet-aired episodes — broadcast viewers know to wait, streaming viewers
can mark ahead.

## Draft — open questions
- Placement: overview row, standalone page, or discover?
- Is a dedicated `/watched/upnext` endpoint preferred over computing client-side?
- Definition of "next": currently first unwatched episode from the latest watched season.

Not included yet: rating from the card; the "upcoming calendar" half of #1008
(depends on a periodic refresh mechanism, #1048/#1049).

## Testing
Ran locally (Go + SvelteKit). Marking advances the card; the row clears when a show
is fully watched.
