### PR TITLE
fix(search): don't trim the query while typing (drops trailing space)

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -68,8 +68,13 @@
 		searchTimeout = window.setTimeout(
 			() => {
 				const target = ev.target as HTMLInputElement;
-				const query = target?.value.trim();
-				if (!query) return;
+				// Keep the value exactly as typed (do NOT trim here). The input is
+				// bound to store.searchQuery, which is reset from the URL query after
+				// each debounced navigation; trimming would drop a trailing space the
+				// user just typed, making "Mon voisin" collapse into "Monvoisin".
+				// We still skip whitespace-only queries below.
+				const query = target?.value ?? "";
+				if (!query.trim()) return;
 				const currentSearchType = page.url.searchParams.get("type");
 				const searchParams = new URLSearchParams({
 					query: encodeURIComponent(query),


### PR DESCRIPTION
## Bug
Typing a multi-word query with a brief pause after a space drops the space:
e.g. typing `Mon voisin` (pausing after the space) becomes `Monvoisin` and returns
no results. It's intermittent — it depends on the search debounce firing while the
trailing space is the last character typed.

## Cause
In `src/routes/(app)/+layout.svelte`, the debounced search handler trims the input
value (`target.value.trim()`) before building the `/search` URL. The search input is
bound to `store.searchQuery`, which is reset from the URL query after each navigation.
So when the debounce fires right after a trailing space, the trimmed value (`Mon`) is
written back into the input, dropping the space the user just typed; the next keystroke
then concatenates (`Monv…`).

## Fix
Keep the value exactly as typed for the query, and only skip whitespace-only searches
(`if (!query.trim()) return;`). Nothing trimmed flows back into the bound input.

## Testing
Typing `Mon voisin` with a pause after the space now keeps the space and returns results.
