### PR TITLE
feat: configurable metadata language (TMDB_LANG) with English fallback

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -66,6 +66,12 @@ type ServerConfig struct {
 	// If unprovided, the default Watcharr API key will be used.
 	TMDB_KEY string `json:",omitempty"`
 
+	// Optional: Language for TMDB metadata (titles, overviews, posters).
+	// ISO 639-1, optionally with a region (e.g. "fr-FR"). Defaults to "en-US".
+	// Note: changing this affects newly-fetched content; already-stored content
+	// keeps its previous language until refreshed.
+	TMDB_LANG string `json:",omitempty"`
+
 	// Optional: Point to Plex install to enable plex features.
 	PLEX_HOST string `json:",omitempty"`
 
@@ -106,6 +112,7 @@ func (c *ServerConfig) GetSafe() ServerConfig {
 		JELLYFIN_HOST:   c.JELLYFIN_HOST,
 		USE_EMBY:        c.USE_EMBY,
 		TMDB_KEY:        c.TMDB_KEY,
+		TMDB_LANG:       c.TMDB_LANG,
 		PLEX_HOST:       c.PLEX_HOST,
 		PLEX_MACHINE_ID: c.PLEX_MACHINE_ID,
 		DEBUG:           c.DEBUG,
@@ -135,6 +142,8 @@ func (c *ServerConfig) Get(s string) (ServerConfigGetByName, error) {
 		return ServerConfigGetByName{Value: c.SIGNUP_ENABLED}, nil
 	case "TMDB_KEY":
 		return ServerConfigGetByName{Value: c.TMDB_KEY}, nil
+	case "TMDB_LANG":
+		return ServerConfigGetByName{Value: c.TMDB_LANG}, nil
 	case "PLEX_HOST":
 		return ServerConfigGetByName{Value: c.PLEX_HOST}, nil
 	case "PLEX_MACHINE_ID":
@@ -161,6 +170,8 @@ func (c *ServerConfig) UpdateConfig(k string, v any) error {
 		c.SIGNUP_ENABLED = v.(bool)
 	} else if k == "TMDB_KEY" {
 		c.TMDB_KEY = v.(string)
+	} else if k == "TMDB_LANG" {
+		c.TMDB_LANG = v.(string)
 	} else if k == "DEBUG" {
 		c.DEBUG = v.(bool)
 		logging.SetLevel(c.DEBUG)
@@ -263,6 +274,7 @@ func generateConfig() (*ServerConfig, error) {
 		JWT_SECRET: key,
 		// Other defaults..
 		DEFAULT_COUNTRY: "US",
+		TMDB_LANG:       "en-US",
 		SIGNUP_ENABLED:  true,
 	}
 	barej, err := json.MarshalIndent(cfg, "", "\t")

--- a/server/feature/content/content.go
+++ b/server/feature/content/content.go
@@ -424,6 +424,22 @@ func (s *Service) MovieDetails(
 		return tmdb.TMDBMovieDetails{},
 			errors.New("failed to complete movie details request")
 	}
+	// English fallback: TMDB returns empty text fields when there's no translation
+	// in the configured language, so backfill from en-US when needed.
+	if s.tmdb.GetLang() != "en-US" && (resp.Overview == "" || resp.Title == "" || resp.PosterPath == "") {
+		en := new(tmdb.TMDBMovieDetails)
+		if e := s.tmdb.Request("/movie/"+id, map[string]string{"language": "en-US"}, &en); e == nil {
+			if resp.Overview == "" {
+				resp.Overview = en.Overview
+			}
+			if resp.Title == "" {
+				resp.Title = en.Title
+			}
+			if resp.PosterPath == "" {
+				resp.PosterPath = en.PosterPath
+			}
+		}
+	}
 	resp.WatchProvidersTransformed = transformProviders(&resp.WatchProviders, country)
 	resp.WatchProviders = nil // We don't want this to linger around (in cache) since we have the transformed version now..
 	go s.cacheContentMovie(*resp, true)
@@ -456,6 +472,22 @@ func (s *Service) TvDetails(
 	if err != nil {
 		slog.Error("Failed to complete tv details request!", "error", err.Error())
 		return tmdb.TMDBShowDetails{}, errors.New("failed to complete tv details request")
+	}
+	// English fallback: TMDB returns empty text fields when there's no translation
+	// in the configured language, so backfill from en-US when needed.
+	if s.tmdb.GetLang() != "en-US" && (resp.Overview == "" || resp.Name == "" || resp.PosterPath == "") {
+		en := new(tmdb.TMDBShowDetails)
+		if e := s.tmdb.Request("/tv/"+id, map[string]string{"language": "en-US"}, &en); e == nil {
+			if resp.Overview == "" {
+				resp.Overview = en.Overview
+			}
+			if resp.Name == "" {
+				resp.Name = en.Name
+			}
+			if resp.PosterPath == "" {
+				resp.PosterPath = en.PosterPath
+			}
+		}
 	}
 	resp.WatchProvidersTransformed = transformProviders(&resp.WatchProviders, country)
 	resp.WatchProviders = nil // We don't want this to linger around (in cache) since we have the transformed version now..

--- a/server/feature/content/content.go
+++ b/server/feature/content/content.go
@@ -340,6 +340,36 @@ func (s *Service) SearchContent(query string, pageNum int) (tmdb.TMDBSearchMulti
 		slog.Error("Failed to complete multi search request!", "error", err.Error())
 		return tmdb.TMDBSearchMultiResponse{}, errors.New("failed to complete multi search request")
 	}
+	// English fallback for search overviews: TMDB returns empty overviews for
+	// entries with no translation in the configured language. Do a single extra
+	// en-US search and backfill by id, only when something is actually missing.
+	if s.tmdb.GetLang() != "en-US" {
+		missing := false
+		for i := range resp.Results {
+			if resp.Results[i].Overview == "" {
+				missing = true
+				break
+			}
+		}
+		if missing {
+			en := new(tmdb.TMDBSearchMultiResponse)
+			if e := s.tmdb.Request("/search/multi", map[string]string{
+				"query": query, "page": strconv.Itoa(pageNum), "language": "en-US",
+			}, &en); e == nil {
+				enOverview := make(map[int]string, len(en.Results))
+				for i := range en.Results {
+					enOverview[en.Results[i].ID] = en.Results[i].Overview
+				}
+				for i := range resp.Results {
+					if resp.Results[i].Overview == "" {
+						if ov := enOverview[resp.Results[i].ID]; ov != "" {
+							resp.Results[i].Overview = ov
+						}
+					}
+				}
+			}
+		}
+	}
 	ContentStore.Set(cacheKey, resp, time.Hour*24)
 	return *resp, nil
 }

--- a/server/feature/content/content.go
+++ b/server/feature/content/content.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	gocache "github.com/robfig/go-cache"
@@ -714,6 +716,57 @@ func (s *Service) PopularPeople(pageNum int) (tmdb.TMDBPopularPeople, error) {
 	}
 	ContentStore.Set(cacheKey, resp, time.Hour*24)
 	return *resp, nil
+}
+
+// LanguageOption is a selectable metadata language (for the TMDB_LANG setting).
+type LanguageOption struct {
+	Code string `json:"code"` // TMDB "language" value, e.g. "fr-FR"
+	Name string `json:"name"` // Human label, e.g. "French (FR)"
+}
+
+// Languages returns the list of TMDB-supported translation languages
+// (primary translations), with human-readable labels, for a dropdown.
+func (s *Service) Languages() ([]LanguageOption, error) {
+	cacheKey := cache.CreateCacheKey("Languages")
+	cached := new([]LanguageOption)
+	if cache.GetCache(ContentStore, cacheKey, &cached) {
+		return *cached, nil
+	}
+	var prim []string
+	if err := s.tmdb.Request("/configuration/primary_translations", map[string]string{}, &prim); err != nil {
+		slog.Error("Languages: primary_translations request failed", "error", err)
+		return nil, errors.New("failed to fetch languages")
+	}
+	var langs []struct {
+		Iso6391     string `json:"iso_639_1"`
+		EnglishName string `json:"english_name"`
+	}
+	if err := s.tmdb.Request("/configuration/languages", map[string]string{}, &langs); err != nil {
+		slog.Error("Languages: languages request failed", "error", err)
+		return nil, errors.New("failed to fetch languages")
+	}
+	nameByIso := make(map[string]string, len(langs))
+	for _, l := range langs {
+		nameByIso[l.Iso6391] = l.EnglishName
+	}
+	out := make([]LanguageOption, 0, len(prim))
+	for _, code := range prim {
+		lang, region := code, ""
+		if i := strings.Index(code, "-"); i > 0 {
+			lang, region = code[:i], code[i+1:]
+		}
+		name := nameByIso[lang]
+		if name == "" {
+			name = lang
+		}
+		if region != "" {
+			name = name + " (" + region + ")"
+		}
+		out = append(out, LanguageOption{Code: code, Name: name})
+	}
+	sort.Slice(out, func(a, b int) bool { return out[a].Name < out[b].Name })
+	ContentStore.Set(cacheKey, &out, time.Hour*24)
+	return out, nil
 }
 
 func (s *Service) Regions() (tmdb.TMDBRegions, error) {

--- a/server/feature/content/content.go
+++ b/server/feature/content/content.go
@@ -238,6 +238,47 @@ func (s *Service) cacheContentMovie(content tmdb.TMDBMovieDetails, onlyUpdate bo
 }
 
 // Get content from our db cache, or cache it if it doesn't exist.
+// fillTvFallback backfills empty text/poster fields from en-US when the
+// configured language has no translation (TMDB returns empty fields in that case).
+func (s *Service) fillTvFallback(id string, c *tmdb.TMDBShowDetails) {
+	if s.tmdb.GetLang() == "en-US" || (c.Overview != "" && c.Name != "" && c.PosterPath != "") {
+		return
+	}
+	en := new(tmdb.TMDBShowDetails)
+	if err := s.tmdb.Request("/tv/"+id, map[string]string{"language": "en-US"}, &en); err != nil {
+		return
+	}
+	if c.Overview == "" {
+		c.Overview = en.Overview
+	}
+	if c.Name == "" {
+		c.Name = en.Name
+	}
+	if c.PosterPath == "" {
+		c.PosterPath = en.PosterPath
+	}
+}
+
+// fillMovieFallback: same as fillTvFallback but for movies.
+func (s *Service) fillMovieFallback(id string, c *tmdb.TMDBMovieDetails) {
+	if s.tmdb.GetLang() == "en-US" || (c.Overview != "" && c.Title != "" && c.PosterPath != "") {
+		return
+	}
+	en := new(tmdb.TMDBMovieDetails)
+	if err := s.tmdb.Request("/movie/"+id, map[string]string{"language": "en-US"}, &en); err != nil {
+		return
+	}
+	if c.Overview == "" {
+		c.Overview = en.Overview
+	}
+	if c.Title == "" {
+		c.Title = en.Title
+	}
+	if c.PosterPath == "" {
+		c.PosterPath = en.PosterPath
+	}
+}
+
 func (s *Service) GetOrCacheContent(contentType entity.ContentType, tmdbId int) (entity.Content, error) {
 	var content entity.Content
 	// Look in db for content.
@@ -259,6 +300,7 @@ func (s *Service) GetOrCacheContent(contentType entity.ContentType, tmdbId int) 
 				slog.Error("Failed to unmarshal movie details", "error", err)
 				return entity.Content{}, errors.New("failed to process movie details response")
 			}
+			s.fillMovieFallback(strconv.Itoa(tmdbId), c)
 			content, err = s.cacheContentMovie(*c, false)
 			if err != nil {
 				slog.Error("GetOrCacheContent: failed to cache movie content", "type", contentType, "content_id", tmdbId, "err", err)
@@ -271,6 +313,7 @@ func (s *Service) GetOrCacheContent(contentType entity.ContentType, tmdbId int) 
 				slog.Error("Failed to unmarshal tv details", "error", err)
 				return entity.Content{}, errors.New("failed to process tv details response")
 			}
+			s.fillTvFallback(strconv.Itoa(tmdbId), c)
 			content, err = s.cacheContentTv(*c, false)
 			if err != nil {
 				slog.Error("GetOrCacheContent: failed to cache tv content", "type", contentType, "content_id", tmdbId, "err", err)
@@ -424,22 +467,7 @@ func (s *Service) MovieDetails(
 		return tmdb.TMDBMovieDetails{},
 			errors.New("failed to complete movie details request")
 	}
-	// English fallback: TMDB returns empty text fields when there's no translation
-	// in the configured language, so backfill from en-US when needed.
-	if s.tmdb.GetLang() != "en-US" && (resp.Overview == "" || resp.Title == "" || resp.PosterPath == "") {
-		en := new(tmdb.TMDBMovieDetails)
-		if e := s.tmdb.Request("/movie/"+id, map[string]string{"language": "en-US"}, &en); e == nil {
-			if resp.Overview == "" {
-				resp.Overview = en.Overview
-			}
-			if resp.Title == "" {
-				resp.Title = en.Title
-			}
-			if resp.PosterPath == "" {
-				resp.PosterPath = en.PosterPath
-			}
-		}
-	}
+	s.fillMovieFallback(id, resp)
 	resp.WatchProvidersTransformed = transformProviders(&resp.WatchProviders, country)
 	resp.WatchProviders = nil // We don't want this to linger around (in cache) since we have the transformed version now..
 	go s.cacheContentMovie(*resp, true)
@@ -473,22 +501,7 @@ func (s *Service) TvDetails(
 		slog.Error("Failed to complete tv details request!", "error", err.Error())
 		return tmdb.TMDBShowDetails{}, errors.New("failed to complete tv details request")
 	}
-	// English fallback: TMDB returns empty text fields when there's no translation
-	// in the configured language, so backfill from en-US when needed.
-	if s.tmdb.GetLang() != "en-US" && (resp.Overview == "" || resp.Name == "" || resp.PosterPath == "") {
-		en := new(tmdb.TMDBShowDetails)
-		if e := s.tmdb.Request("/tv/"+id, map[string]string{"language": "en-US"}, &en); e == nil {
-			if resp.Overview == "" {
-				resp.Overview = en.Overview
-			}
-			if resp.Name == "" {
-				resp.Name = en.Name
-			}
-			if resp.PosterPath == "" {
-				resp.PosterPath = en.PosterPath
-			}
-		}
-	}
+	s.fillTvFallback(id, resp)
 	resp.WatchProvidersTransformed = transformProviders(&resp.WatchProviders, country)
 	resp.WatchProviders = nil // We don't want this to linger around (in cache) since we have the transformed version now..
 	go s.cacheContentTv(*resp, true)

--- a/server/feature/content/router.go
+++ b/server/feature/content/router.go
@@ -60,6 +60,8 @@ func (r *Router) AddRoutes() {
 	content.GET("/person/:id/credits", r.GetPersonCredits)
 	// Available regions for watch providers
 	content.GET("/regions", r.GetRegions)
+	// Available metadata languages (for the TMDB_LANG setting)
+	content.GET("/languages", r.GetLanguages)
 }
 
 func (r *Router) GetMovieDetails(c *gin.Context) {
@@ -270,4 +272,13 @@ func (r *Router) GetRegions(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, re)
+}
+
+func (r *Router) GetLanguages(c *gin.Context) {
+	langs, err := r.cs.Languages()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, router.ErrorResponse{Error: err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, langs)
 }

--- a/server/media/tmdb/tmdb.go
+++ b/server/media/tmdb/tmdb.go
@@ -14,12 +14,14 @@ import (
 // fix needing so many extra structs for the *WithWatched types and functions)
 
 type TMDB struct {
-	Key string
+	Key  string
+	Lang string
 }
 
-func NewTMDB(key string) *TMDB {
+func NewTMDB(key string, lang string) *TMDB {
 	return &TMDB{
-		Key: key,
+		Key:  key,
+		Lang: lang,
 	}
 }
 
@@ -28,6 +30,15 @@ func (t *TMDB) GetKey() string {
 		return t.Key //Config.TMDB_KEY
 	}
 	return "d047fa61d926371f277e7a83c9c4ff2c"
+}
+
+// GetLang returns the configured TMDB metadata language (ISO 639-1, optionally
+// with a region, e.g. "fr-FR"), falling back to English when unset.
+func (t *TMDB) GetLang() string {
+	if t.Lang != "" {
+		return t.Lang
+	}
+	return "en-US"
 }
 
 func (t *TMDB) APIRequest(ep string, p map[string]string) ([]byte, error) {
@@ -43,7 +54,7 @@ func (t *TMDB) APIRequest(ep string, p map[string]string) ([]byte, error) {
 	// Query params
 	params := url.Values{}
 	params.Add("api_key", t.GetKey())
-	params.Add("language", "en-US")
+	params.Add("language", t.GetLang())
 	for k, v := range p {
 		params.Add(k, v)
 	}

--- a/server/media/tmdb/tmdb.go
+++ b/server/media/tmdb/tmdb.go
@@ -54,7 +54,11 @@ func (t *TMDB) APIRequest(ep string, p map[string]string) ([]byte, error) {
 	// Query params
 	params := url.Values{}
 	params.Add("api_key", t.GetKey())
-	params.Add("language", t.GetLang())
+	// Let callers override the language per-request (used for the English
+	// fallback when a translation is missing); otherwise use the configured one.
+	if _, ok := p["language"]; !ok {
+		params.Add("language", t.GetLang())
+	}
 	for k, v := range p {
 		params.Add(k, v)
 	}

--- a/server/watcharr.go
+++ b/server/watcharr.go
@@ -196,7 +196,7 @@ func main() {
 	api := gine.Group("/api")
 	br := router.NewBaseRouter(db, api, cfg)
 
-	t := tmdb.NewTMDB(cfg.TMDB_KEY)
+	t := tmdb.NewTMDB(cfg.TMDB_KEY, cfg.TMDB_LANG)
 
 	plexService := plex.NewService(cfg)
 	authService := auth.NewService(db, cfg, plexService)

--- a/src/lib/LanguageDropDown.svelte
+++ b/src/lib/LanguageDropDown.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import axios from "axios";
+	import DropDown from "./DropDown.svelte";
+	import type { DropDownItem } from "@/types";
+	import Error from "./Error.svelte";
+
+	interface Props {
+		selectedLang?: string;
+		disabled?: boolean;
+		onChange: (lang: string) => void;
+	}
+
+	let {
+		selectedLang = $bindable("en-US"),
+		disabled = false,
+		onChange,
+	}: Props = $props();
+
+	let mappedLangs: DropDownItem[] = $state<DropDownItem[]>([]);
+
+	async function getLanguages() {
+		const l = (await axios.get(`/content/languages`)).data as {
+			code: string;
+			name: string;
+		}[];
+		mappedLangs = l.map((ll) => ({ id: ll.code, value: ll.name }) as DropDownItem);
+	}
+</script>
+
+{#await getLanguages() then}
+	<DropDown
+		placeholder="Select a language"
+		bind:active={selectedLang}
+		options={mappedLangs}
+		onChange={() => onChange(selectedLang)}
+		isDropDownItem={true}
+		{disabled}
+	/>
+{:catch err}
+	<Error error={err} pretty="Failed to load languages!" />
+{/await}

--- a/src/routes/(app)/server/+page.svelte
+++ b/src/routes/(app)/server/+page.svelte
@@ -20,6 +20,7 @@
 	import Stat from "@/lib/stats/Stat.svelte";
 	import TwitchModal from "./modals/TwitchModal.svelte";
 	import RegionDropDown from "@/lib/RegionDropDown.svelte";
+	import LanguageDropDown from "@/lib/LanguageDropDown.svelte";
 	import TaskScheduleModal from "./modals/TaskScheduleModal.svelte";
 	import TrustedHeaderAuthModal from "./modals/TrustedHeaderAuthModal.svelte";
 
@@ -40,6 +41,29 @@
 	let jfDisabled = $state(false);
 	let tmdbkDisabled = $state(false);
 	let tmdbLangDisabled = $state(false);
+
+	// Update the default country, and (choix C) pre-fill the metadata language to
+	// the one matching that country when such a translation exists (overridable).
+	async function onCountryChange(c: string) {
+		if (!serverConfig) return;
+		countryDisabled = true;
+		updateServerConfig("DEFAULT_COUNTRY", c, () => {
+			countryDisabled = false;
+		});
+		try {
+			const langs = (await axios.get(`/content/languages`)).data as {
+				code: string;
+				name: string;
+			}[];
+			const match = langs.find((l) => l.code.toUpperCase().endsWith("-" + c.toUpperCase()));
+			if (match && serverConfig.TMDB_LANG !== match.code) {
+				serverConfig.TMDB_LANG = match.code;
+				updateServerConfig("TMDB_LANG", match.code, () => {});
+			}
+		} catch (err) {
+			console.error("onCountryChange: failed to pre-fill language", err);
+		}
+	}
 	let plexHostDisabled = $state(false);
 	let countryDisabled = $state(false);
 	let useEmbyDisabled = $state(false);
@@ -144,12 +168,7 @@
 						<RegionDropDown
 							selectedCountry={serverConfig.DEFAULT_COUNTRY}
 							disabled={countryDisabled}
-							onChange={(c) => {
-								countryDisabled = true;
-								updateServerConfig("DEFAULT_COUNTRY", c, () => {
-									countryDisabled = false;
-								});
-							}}
+							onChange={(c) => onCountryChange(c)}
 						/>
 					</Setting>
 					<Setting
@@ -237,17 +256,15 @@
 						title="TMDB Language"
 						desc="Language for content metadata (titles, overviews, posters), e.g. fr-FR. Applies to newly-fetched content."
 					>
-						<input
-							type="text"
-							placeholder="en-US"
-							bind:value={serverConfig.TMDB_LANG}
-							onblur={() => {
+						<LanguageDropDown
+							selectedLang={serverConfig.TMDB_LANG}
+							disabled={tmdbLangDisabled}
+							onChange={(l) => {
 								tmdbLangDisabled = true;
-								updateServerConfig("TMDB_LANG", serverConfig!.TMDB_LANG, () => {
+								updateServerConfig("TMDB_LANG", l, () => {
 									tmdbLangDisabled = false;
 								});
 							}}
-							disabled={tmdbLangDisabled}
 						/>
 					</Setting>
 					<Setting

--- a/src/routes/(app)/server/+page.svelte
+++ b/src/routes/(app)/server/+page.svelte
@@ -39,6 +39,7 @@
 	let debugDisabled = $state(false);
 	let jfDisabled = $state(false);
 	let tmdbkDisabled = $state(false);
+	let tmdbLangDisabled = $state(false);
 	let plexHostDisabled = $state(false);
 	let countryDisabled = $state(false);
 	let useEmbyDisabled = $state(false);
@@ -230,6 +231,23 @@
 								});
 							}}
 							disabled={tmdbkDisabled}
+						/>
+					</Setting>
+					<Setting
+						title="TMDB Language"
+						desc="Language for content metadata (titles, overviews, posters), e.g. fr-FR. Applies to newly-fetched content."
+					>
+						<input
+							type="text"
+							placeholder="en-US"
+							bind:value={serverConfig.TMDB_LANG}
+							onblur={() => {
+								tmdbLangDisabled = true;
+								updateServerConfig("TMDB_LANG", serverConfig!.TMDB_LANG, () => {
+									tmdbLangDisabled = false;
+								});
+							}}
+							disabled={tmdbLangDisabled}
 						/>
 					</Setting>
 					<Setting

--- a/src/types.ts
+++ b/src/types.ts
@@ -579,6 +579,7 @@ export interface ServerConfig {
 	USE_EMBY: boolean;
 	SIGNUP_ENABLED: boolean;
 	TMDB_KEY: string;
+	TMDB_LANG: string;
 	PLEX_HOST: string;
 	PLEX_MACHINE_ID: string;
 	SONARR: SonarrSettings[];


### PR DESCRIPTION
Implements #772 — fetch content metadata (titles, overviews, posters) from TMDB in a
chosen language.

## What
- New server setting **`TMDB_LANG`** (default `en-US`), edited from the server dashboard
  via a **language dropdown** (populated from TMDB primary translations). Selecting the
  **Default Country pre-fills** the matching language (still overridable).
- **English fallback**: TMDB returns empty fields when a translation is missing, so
  titles / overviews / posters are backfilled from `en-US`. Applied on **detail pages**,
  on **add/import**, and in **search results** (one extra en-US search, only when needed).
- New endpoint `GET /content/languages`.

## Relationship to #801
This is the **metadata** half (content coming from TMDB), independent of UI translation
(#801, Weblate/i18next).

## Design note / open question
The language is a **global server setting** here (simplest; my use case has a single
active user). #772 hints at a per-user selector (like the region dropdown): that's more
involved, because stored content (the `Content` table) is shared across users, so
per-user metadata would need per-language storage. I'm happy to take it that way, or to
align with how you're thinking about #801 / the data-refresh work — let me know your
preference.

## Notes
- Already-stored content keeps its previous language until re-fetched (opening a title
  refreshes it; a full re-import converts everything). A dedicated "refresh all" is
  intentionally left out of this PR.
- Opened as a **draft**: sharing a working solution (running on my own instance) for
  direction before any polishing.

## Testing
With `TMDB_LANG=fr-FR`: search, detail pages, and add/import all return French, with an
English fallback for untranslated entries.
