### PR TITLE
feat: quick media-type toggle (All/TV/Movies) with per-mode filters & sort

### DIFF
--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -7,7 +7,7 @@
 	import Spinner from "@/lib/Spinner.svelte";
 	import infScroll from "@/lib/util/infScroll";
 	import paginatedLoader from "@/lib/util/paginatedLoader.svelte";
-	import { clearActiveFilters, store } from "@/store.svelte";
+	import { clearActiveFilters, setWatchedListMode, store } from "@/store.svelte";
 	import type { Media } from "@/types";
 	import axios, { type GenericAbortSignal } from "axios";
 	import { onDestroy, untrack } from "svelte";
@@ -43,6 +43,11 @@
 			return;
 		}
 		dataLoader.runFn();
+	}
+
+	// True when the type filter is set to exactly this single media type.
+	function isTypeOnly(t: string): boolean {
+		return store.activeFilters?.type?.length === 1 && store.activeFilters.type[0] === t;
 	}
 
 	// NOTE: This effect also handles initial load of data.
@@ -81,6 +86,30 @@
 	{JSON.stringify(store.activeFilters)} <b>queryp:</b>
 	{JSON.stringify(store.sortAndFiltersForQueryParams)}</span
 > -->
+
+<div class="type-toggle">
+	<button
+		class="plain"
+		data-active={!store.activeFilters?.type?.length}
+		onclick={() => setWatchedListMode("all")}
+	>
+		All
+	</button>
+	<button
+		class="plain"
+		data-active={isTypeOnly("tv")}
+		onclick={() => setWatchedListMode("tv")}
+	>
+		<Icon i="tv" wh={18} /> TV Shows
+	</button>
+	<button
+		class="plain"
+		data-active={isTypeOnly("movie")}
+		onclick={() => setWatchedListMode("movie")}
+	>
+		<Icon i="film" wh={18} /> Movies
+	</button>
+</div>
 
 <PosterList>
 	{#if dataLoader.state.data?.length > 0}
@@ -136,6 +165,42 @@
 {/if} -->
 
 <style lang="scss">
+	.type-toggle {
+		display: flex;
+		flex-flow: row;
+		flex-wrap: wrap;
+		gap: 10px;
+		justify-content: center;
+		margin: 0 auto 15px auto;
+
+		button {
+			display: flex;
+			flex-flow: row;
+			align-items: center;
+			gap: 8px;
+			padding: 8px 14px;
+			border-radius: 8px;
+			font-size: 14px;
+			color: $text-color;
+			fill: $text-color;
+			transition:
+				background-color 150ms ease,
+				color 150ms ease,
+				outline 150ms ease;
+
+			&:hover,
+			&[data-active="true"] {
+				color: $bg-color;
+				fill: $bg-color;
+				background-color: $accent-color-hover;
+			}
+
+			&[data-active="true"] {
+				outline: 3px solid $accent-color;
+			}
+		}
+	}
+
 	.empty-list {
 		display: flex;
 		flex-flow: column;

--- a/src/store.svelte.ts
+++ b/src/store.svelte.ts
@@ -15,12 +15,37 @@ import { toggleTheme } from "./lib/util/theme";
 
 export const defaultSort = ["DATEADDED", "DOWN"];
 
+export type WatchedListMode = "all" | "tv" | "movie";
+
+/** Type filter array for a given view mode. */
+export function typeForMode(mode: WatchedListMode): string[] {
+	if (mode === "tv") return ["tv"];
+	if (mode === "movie") return ["movie"];
+	return [];
+}
+
+/**
+ * Derive the current view mode from a type filter, or undefined when the
+ * type filter is a combination that no single mode represents.
+ */
+function modeOf(type: string[] | undefined): WatchedListMode | undefined {
+	if (!type?.length) return "all";
+	if (type.length === 1 && type[0] === "tv") return "tv";
+	if (type.length === 1 && type[0] === "movie") return "movie";
+	return undefined;
+}
+
 interface Store {
 	userInfo: PrivateUser | undefined;
 	userSettings: UserSettings | undefined;
 	notifications: Notification[];
 	activeSort: string[];
 	activeFilters: Filters;
+	// Remembered status filter and sort for each watched-list view mode
+	// (all/tv/movie), so switching between shows and movies keeps each mode's
+	// own filters and sort order.
+	filterModes: Record<string, string[]>;
+	sortModes: Record<string, string[]>;
 	sortAndFiltersForQueryParams: {};
 	appTheme: Theme;
 	importedList:
@@ -52,6 +77,8 @@ const _store: Store = $state({
 	notifications: [],
 	activeSort: defaultSort,
 	activeFilters: { type: [], status: [] },
+	filterModes: { all: [], tv: [], movie: [] },
+	sortModes: { all: defaultSort, tv: defaultSort, movie: defaultSort },
 	appTheme: "system",
 	sortAndFiltersForQueryParams: {},
 	importedList: undefined,
@@ -109,6 +136,12 @@ export const store = {
 	set activeSort(v) {
 		_store.activeSort = v;
 		localStorage.setItem("activeFilter", JSON.stringify(v));
+		// Remember this mode's sort so switching modes restores it.
+		const mode = modeOf(_store.activeFilters?.type);
+		if (mode) {
+			_store.sortModes[mode] = v;
+			localStorage.setItem("sortModes", JSON.stringify(_store.sortModes));
+		}
 		console.debug("Store: Saved activeSort:", v);
 		updateSortAndFiltersForQueryParams();
 	},
@@ -125,8 +158,20 @@ export const store = {
 	set activeFilters(v) {
 		_store.activeFilters = v;
 		localStorage.setItem("activeFilterReal", JSON.stringify(v));
+		// Remember this mode's status filter so switching modes restores it.
+		const mode = modeOf(v?.type);
+		if (mode) {
+			_store.filterModes[mode] = v?.status ?? [];
+			localStorage.setItem("filterModes", JSON.stringify(_store.filterModes));
+		}
 		console.debug("Store: Saved activeFilters:", v);
 		updateSortAndFiltersForQueryParams();
+	},
+	get filterModes() {
+		return _store.filterModes;
+	},
+	get sortModes() {
+		return _store.sortModes;
 	},
 	/**
 	 * Return our `activeSort` and `activeFilters` in an object
@@ -236,6 +281,21 @@ export const clearActiveFilters = () => {
 	store.activeFilters = { type: [], status: [] };
 };
 
+/**
+ * Switch the watched-list view mode (all/tv/movie), restoring the status
+ * filter last used in that mode.
+ */
+export const setWatchedListMode = (mode: WatchedListMode) => {
+	// Set the type filter first so the mode is derivable, then restore this
+	// mode's remembered status and sort.
+	store.activeFilters = {
+		...store.activeFilters,
+		type: typeForMode(mode),
+		status: store.filterModes[mode] ?? [],
+	};
+	store.activeSort = store.sortModes[mode] ?? defaultSort;
+};
+
 if (browser) {
 	rehydrateStore();
 }
@@ -265,6 +325,29 @@ function rehydrateStore() {
 		console.debug(
 			"rehydrateStore: Restored activeFilters:",
 			$state.snapshot(store.activeFilters),
+		);
+	}
+	// Restore per-mode remembered filters
+	const fm = localStorage.getItem("filterModes");
+	if (fm) {
+		_store.filterModes = { all: [], tv: [], movie: [], ...JSON.parse(fm) };
+		console.debug(
+			"rehydrateStore: Restored filterModes:",
+			$state.snapshot(store.filterModes),
+		);
+	}
+	// Restore per-mode remembered sort
+	const sm = localStorage.getItem("sortModes");
+	if (sm) {
+		_store.sortModes = {
+			all: defaultSort,
+			tv: defaultSort,
+			movie: defaultSort,
+			...JSON.parse(sm),
+		};
+		console.debug(
+			"rehydrateStore: Restored sortModes:",
+			$state.snapshot(store.sortModes),
 		);
 	}
 	// After restoring activeSort and activeFilter, set


### PR DESCRIPTION
Adds a small, always-visible toggle at the top of the watched list —
**All / TV Shows / Movies** (reusing the search's `film` / `tv` icons) — so you can
switch between shows and movies in one click instead of opening the filter menu. It
drives the existing type filter, so it works with everything already there.

## What makes it useful day-to-day
- **Each mode remembers its own status filter and sort order.** For example: TV Shows →
  only *watching*, Movies → everything, each with its own sort. Switching modes restores
  that mode's view instead of clobbering it. (Before, applying a *watching* filter to see
  in-progress shows would also hide all your finished movies — the two filters are ANDed.)
- Everything is persisted to `localStorage` and rehydrated on load.

## Implementation
- `store.svelte.ts`: `filterModes` / `sortModes` (status + sort per mode), a
  `setWatchedListMode(mode)` helper, and `modeOf()` to derive the current mode from the
  type filter. The `activeFilters` / `activeSort` setters remember the current mode's
  values; rehydrate restores them.
- `(app)/+page.svelte`: the toggle UI + styling (mirrors the search `MediaTypeFilter`).

## Notes
- Per-mode memory starts empty, so the first time you set a filter/sort in a mode it's
  remembered from then on — no behaviour change until you opt in.
- Running on my own instance in daily use. Happy to adjust naming/placement.
