### PR TITLE
Plex: Add `Accept: "application/json"` header so plex returns json again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 These changes are awaiting release:
 
+## Fixed
+
+- Plex Login: Request JSON from plex api so that it doesn't return XML.
+
 # [4.1.0] - 2026-07-19T14:18:00Z
 
 ## Changed

--- a/src/lib/util/plex.ts
+++ b/src/lib/util/plex.ts
@@ -68,6 +68,9 @@ export function preparePlexAuth(): Plex {
 			// Don't really want to give all the possible headers,
 			// trying to minimize it to what gets it working.
 			headers: {
+				// So plex api returns json.
+				Accept: "application/json",
+				// Plex product specific headers:
 				"X-Plex-Product": "Watcharr",
 				"X-Plex-Client-Identifier": clientId,
 				"X-Plex-Version": "Plex OAuth",


### PR DESCRIPTION
### Changes made

I think the plex api default used to be JSON, which is why it worked, but I guess they changed it to XML. Adding this header asks for JSON response again.

Fixes #1081
