### PR TITLE
Show end year for ended tv shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ These changes are awaiting release:
 - Show `Aired Date` for episodes.
 - Import: Add `rating` column.
 - Import(text list): Support parsing a rating (out of 10, supporting decimals) in square brackets.
+- Show `End Year` for TV Shows that have ended or been canceled.
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ These changes are awaiting release:
 - Import: Add `rating` column.
 - Import(text list): Support parsing a rating (out of 10, supporting decimals) in square brackets.
 - Show `End Year` for TV Shows that have ended or been canceled.
+- Add full release date and last release date to their respective year elements as titles (browser tooltip).
 
 ## Changed
 

--- a/server/domain/media.go
+++ b/server/domain/media.go
@@ -63,6 +63,9 @@ type Media struct {
 	// A link to the database we are using that lists all providers with max details.
 	// (especially for TMDB since it's data from JustWatch isn't available to us).
 	ProvidersFullListLink string `json:"providersFullListLink,omitempty"`
+	// Status of the media (released, ended, etc).
+	// Depending on media type, this will contain different values.
+	Status string `json:"status,omitempty"`
 
 	//
 	// Properties only for movies/tv.
@@ -78,6 +81,9 @@ type Media struct {
 	// details for the server to fetch fully/verify, i.e fetched full details from
 	// tmdb again to verify if show is anime itself, etc).
 	IsShowAnime bool `json:"isShowAnime,omitempty"`
+	// Last release date.
+	// Currently used for tv shows so frontend can display its end date.
+	ReleaseDateLast time.Time `json:"releaseDateLast,omitzero"`
 
 	//
 	// Properties only for Games

--- a/server/media/tmdb/structs.go
+++ b/server/media/tmdb/structs.go
@@ -335,6 +335,7 @@ func (t *TMDBContentDetails) AsMedia() domain.Media {
 		Rating:          uint(t.VoteAverage * 10),
 		RatingCount:     uint(t.VoteCount),
 		Homepage:        t.Homepage,
+		Status:          t.Status,
 	}
 	// Genres
 	for _, g := range t.Genres {
@@ -533,6 +534,13 @@ func (t *TMDBShowDetails) AsMedia() domain.Media {
 		m.ReleaseDate = releaseDate
 	} else {
 		slog.Error("AsMedia: Failed to parse release date", "name", m.Name, "error", err)
+	}
+	if releaseDateLast, err := time.Parse("2006-01-02", t.LastAirDate); err == nil {
+		m.ReleaseDateLast = releaseDateLast
+	} else {
+		slog.Error("AsMedia: Failed to parse release date last",
+			"name", m.Name,
+			"error", err)
 	}
 	// IDS
 	m.IDs.IMDB = t.ExternalIds.ImdbID

--- a/src/lib/content/Title.svelte
+++ b/src/lib/content/Title.svelte
@@ -1,22 +1,30 @@
 <script lang="ts">
+	import { dateValid } from "../util/date";
+
 	interface Props {
 		homepage?: string;
 		title?: string;
 		releaseDate?: Date;
+		endDate?: Date;
 		voteAverage?: number;
 		voteCount?: number;
 	}
 
-	let { homepage, title, releaseDate, voteAverage, voteCount }: Props =
+	let { homepage, title, releaseDate, endDate, voteAverage, voteCount }: Props =
 		$props();
 
 	// if voteAvg bigger than 10, it is out of 100, so no need to * by 10
-	const vote = voteAverage
-		? Math.round(voteAverage > 10 ? voteAverage : voteAverage * 10) / 10
-		: 0;
+	const vote = $derived(
+		voteAverage
+			? Math.round(voteAverage > 10 ? voteAverage : voteAverage * 10) / 10
+			: 0,
+	);
 	const titleSafe = $derived(title ? title : "Unknown Title");
 	const releaseYear = $derived(
-		releaseDate ? releaseDate.getFullYear() : undefined,
+		dateValid(releaseDate) ? releaseDate.getFullYear() : undefined,
+	);
+	const endYear = $derived(
+		dateValid(endDate) ? endDate.getFullYear() : undefined,
 	);
 </script>
 
@@ -28,7 +36,13 @@
 			<span class="t">{titleSafe}</span>
 		{/if}
 		{#if releaseYear}
-			<span class="year">{releaseYear}</span>
+			<span class="year">
+				<!--First span ends on the line with the #if so there's no whitespace-->
+				<span title={releaseDate?.toLocaleDateString()}>{releaseYear}</span
+				>{#if endYear && endYear != releaseYear}
+					<span title={endDate?.toLocaleDateString()}>-{endYear}</span>
+				{/if}
+			</span>
 		{/if}
 	</span>
 	<span

--- a/src/lib/types/mediaStatus.ts
+++ b/src/lib/types/mediaStatus.ts
@@ -1,0 +1,35 @@
+/**
+ * Media statuses.
+ */
+
+export enum MediaStatusShow {
+	ReturningSeries = "Returning Series",
+	Planned = "Planned",
+	InProduction = "In Production",
+	Ended = "Ended",
+	Canceled = "Canceled",
+	Pilot = "Pilot",
+}
+
+export enum MediaStatusMovie {
+	Rumored = "Rumored",
+	Planned = "Planned",
+	InProduction = "In Production",
+	PostProduction = "Post Production",
+	Released = "Released",
+	Canceled = "Canceled",
+}
+
+/**
+ * Taken from what `https://api.igdb.com/v4/game_statuses` returned at the time.
+ */
+export enum MediaStatusGame {
+	Released = "Released",
+	Alpha = "Alpha",
+	Beta = "Beta",
+	EarlyAccess = "Early Access",
+	Offline = "Offline",
+	Cancelled = "Cancelled",
+	Rumored = "Rumored",
+	Delisted = "Delisted",
+}

--- a/src/lib/util/date.ts
+++ b/src/lib/util/date.ts
@@ -1,0 +1,13 @@
+/**
+ * Date helpers.
+ */
+
+/**
+ * Check if `d` is a **valid** `Date`.
+ *
+ * **NOTE:** Returns `false` even if `d` is an instance of `Date`,
+ * if it doesn't contain a valid date.
+ */
+export function dateValid(d: unknown): d is Date {
+	return d instanceof Date && !isNaN(d.getTime());
+}

--- a/src/routes/(app)/tv/[id]/+page.svelte
+++ b/src/routes/(app)/tv/[id]/+page.svelte
@@ -39,6 +39,7 @@
 	import CountAsPlayModal from "@/lib/watched/CountAsPlayModal.svelte";
 	import { createSignal, type Signal } from "@/lib/util/signal.js";
 	import Genres from "@/lib/content/Genres.svelte";
+	import { MediaStatusShow } from "@/lib/types/mediaStatus.js";
 
 	let { data } = $props();
 
@@ -167,6 +168,11 @@
 							homepage={show.homepage}
 							releaseDate={show.releaseDate
 								? new Date(show.releaseDate)
+								: undefined}
+							endDate={(show.status === MediaStatusShow.Ended ||
+								show.status === MediaStatusShow.Canceled) &&
+							show.releaseDateLast
+								? new Date(show.releaseDateLast)
 								: undefined}
 							voteAverage={show.rating}
 							voteCount={show.ratingCount}

--- a/src/types.ts
+++ b/src/types.ts
@@ -335,6 +335,8 @@ export interface Media {
 	watched?: Watched;
 	similar?: Media[];
 	releaseDate?: string;
+	releaseDateLast?: string;
+	status?: string;
 	extBackdropPath?: string;
 	genres?: MediaGenre[];
 	homepage?: string;


### PR DESCRIPTION
# Changes made

- Show `End Year` for TV Shows that have ended or been canceled.
- Add full release date and last release date to their respective year elements as titles (browser tooltip).

<img width="764" height="404" alt="image" src="https://github.com/user-attachments/assets/b63713f3-b3cd-4edf-bdfe-94aa3fe30a76" />
