### PR TITLE
Add "allowfullscreen" attribute to YouTube trailer iframe

### DIFF
--- a/src/lib/content/VideoEmbedModal.svelte
+++ b/src/lib/content/VideoEmbedModal.svelte
@@ -43,6 +43,7 @@
 				frameborder="0"
 				width="100%"
 				height="100%"
+				allow="fullscreen"
 				allowfullscreen
 			></iframe>
 		</div>

--- a/src/lib/content/VideoEmbedModal.svelte
+++ b/src/lib/content/VideoEmbedModal.svelte
@@ -43,6 +43,7 @@
 				frameborder="0"
 				width="100%"
 				height="100%"
+				allowfullscreen
 			></iframe>
 		</div>
 	{/if}


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

<!-- AI Disclosure: <If you used AI to write the code, please disclose it by uncommenting this line and describing the usage. If AI wrote any of the code, do you fully understand it?> -->

### Changes made

<!-- Describe changes made here. If changes are visual a screenshot could be useful! -->

1 word change. Just added the `allowfullscreen` attribute to the trailer iframe on content pages.

---

Perhaps there is some reason why this shouldn't be a thing, or I'm literally the only person actually watching trailers through this, but it's been driving me insane that I can't fullscreen the trailers using the iframe..