### PR TITLE
Added rating updates on import when rating is previously empty

### DIFF
--- a/server/domain/import.go
+++ b/server/domain/import.go
@@ -43,6 +43,9 @@ var (
 	IMPORT_NOTFOUND ImportResponseType = "IMPORT_NOTFOUND"
 	// Item already exists so couldn't import (unique constraint hit when adding)
 	IMPORT_EXISTS ImportResponseType = "IMPORT_EXISTS"
+	// Item already existed, but it had no rating, so the rating from the
+	// import was filled in on the existing entry.
+	IMPORT_RATING_UPDATED ImportResponseType = "IMPORT_RATING_UPDATED"
 )
 
 type ImportRequest struct {

--- a/server/feature/imprt/import.go
+++ b/server/feature/imprt/import.go
@@ -20,6 +20,7 @@ import (
 type WatchedProvider interface {
 	AddWatched(userId uint, ar domain.WatchedAddRequest, extraProps domain.WatchedAddExtraProps) (entity.Watched, error)
 	GetWatchedItemByTmdbId(userId uint, tmdbId uint, contentType entity.ContentType) (entity.Watched, error)
+	UpdateWatchedRating(userId uint, watchedId uint, rating float64) error
 }
 
 type WatchedSeasonProvider interface {
@@ -121,6 +122,62 @@ func (s *Service) ImportContent(
 	return s.importWithName(userId, &ar)
 }
 
+// Fill in a rating on content that is already on the users list.
+//
+// Content added by a Plex or Jellyfin sync often has no rating, so filling one
+// in from an import is safe in that case. When an import carries a rating for
+// content we already have, we can use it rather than throwing the import away.
+//
+// An existing rating is never overwritten, so re-running an import cannot
+// clobber a rating the user set themselves. Anything we cannot fill in is
+// still reported as IMPORT_EXISTS, exactly as before.
+func (s *Service) fillInMissingRating(
+	userId uint,
+	ar *domain.ImportRequest,
+	props domain.SuccessfulImportProps,
+) domain.ImportResponse {
+	if ar.Rating <= 0 {
+		return domain.ImportResponse{Type: domain.IMPORT_EXISTS}
+	}
+	// Only movies and shows can be looked up by tmdb id.
+	if props.ContentType != util.SupportedMediaMovie &&
+		props.ContentType != util.SupportedMediaShow {
+		return domain.ImportResponse{Type: domain.IMPORT_EXISTS}
+	}
+	existing, err := s.wp.GetWatchedItemByTmdbId(
+		userId,
+		uint(props.TmdbID),
+		entity.ContentType(props.ContentType),
+	)
+	if err != nil {
+		slog.Error("fillInMissingRating: Failed to get the existing watched item",
+			"tmdb_id", props.TmdbID, "error", err)
+		return domain.ImportResponse{Type: domain.IMPORT_EXISTS}
+	}
+	if existing.ID == 0 {
+		slog.Warn("fillInMissingRating: No existing watched item found",
+			"tmdb_id", props.TmdbID)
+		return domain.ImportResponse{Type: domain.IMPORT_EXISTS}
+	}
+	if existing.Rating != 0 {
+		slog.Debug("fillInMissingRating: Existing item is already rated, leaving it be",
+			"watched_id", existing.ID, "rating", existing.Rating)
+		return domain.ImportResponse{Type: domain.IMPORT_EXISTS}
+	}
+	if err := s.wp.UpdateWatchedRating(userId, existing.ID, ar.Rating); err != nil {
+		slog.Error("fillInMissingRating: Failed to update the rating",
+			"watched_id", existing.ID, "error", err)
+		return domain.ImportResponse{Type: domain.IMPORT_EXISTS}
+	}
+	slog.Info("fillInMissingRating: Filled in a missing rating",
+		"watched_id", existing.ID, "rating", ar.Rating)
+	existing.Rating = ar.Rating
+	return domain.ImportResponse{
+		Type:         domain.IMPORT_RATING_UPDATED,
+		WatchedEntry: existing,
+	}
+}
+
 func (s *Service) SuccessfulImport(
 	userId uint,
 	ar *domain.ImportRequest,
@@ -166,9 +223,9 @@ func (s *Service) SuccessfulImport(
 		})
 	if err != nil {
 		if errors.Is(err, domain.ErrWatchedExists) {
-			slog.Error("successfulImport: Must already be on watch list",
-				"error", err)
-			return domain.ImportResponse{Type: domain.IMPORT_EXISTS}
+			slog.Info("successfulImport: Already on watch list, seeing if a"+
+				" missing rating can be filled in", "error", err)
+			return s.fillInMissingRating(userId, ar, props)
 		}
 		slog.Error("successfulImport: Failed to add content as watched",
 			"error", err)

--- a/server/feature/imprt/import_rating_test.go
+++ b/server/feature/imprt/import_rating_test.go
@@ -1,0 +1,188 @@
+package imprt
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sbondCo/Watcharr/database/dbmodel"
+	"github.com/sbondCo/Watcharr/database/entity"
+	"github.com/sbondCo/Watcharr/domain"
+	"github.com/sbondCo/Watcharr/util"
+)
+
+// Stands in for the watched service. Only the methods fillInMissingRating
+// uses are given real behaviour, the rest are here to satisfy the interface.
+type fakeWatchedProvider struct {
+	existing    entity.Watched
+	getErr      error
+	updateErr   error
+	updateCalls []ratingUpdate
+}
+
+type ratingUpdate struct {
+	watchedId uint
+	rating    float64
+}
+
+func (f *fakeWatchedProvider) AddWatched(
+	userId uint,
+	ar domain.WatchedAddRequest,
+	extraProps domain.WatchedAddExtraProps,
+) (entity.Watched, error) {
+	return entity.Watched{}, domain.ErrWatchedExists
+}
+
+func (f *fakeWatchedProvider) GetWatchedItemByTmdbId(
+	userId uint,
+	tmdbId uint,
+	contentType entity.ContentType,
+) (entity.Watched, error) {
+	if f.getErr != nil {
+		return entity.Watched{}, f.getErr
+	}
+	return f.existing, nil
+}
+
+func (f *fakeWatchedProvider) UpdateWatchedRating(
+	userId uint,
+	watchedId uint,
+	rating float64,
+) error {
+	f.updateCalls = append(f.updateCalls, ratingUpdate{watchedId, rating})
+	return f.updateErr
+}
+
+// TestFillInMissingRating covers the rules for filling in a rating on content
+// that is already on the users list: a rating is only ever added when the
+// import has one and the existing entry does not, and an existing rating is
+// never overwritten.
+func TestFillInMissingRating(t *testing.T) {
+	const tmdbId = 43167
+
+	tests := []struct {
+		name string
+		// Rating carried by the import.
+		importRating float64
+		// The entry already on the users list.
+		existing   entity.Watched
+		getErr     error
+		updateErr  error
+		wantType   domain.ImportResponseType
+		wantUpdate bool
+		wantRating float64
+	}{
+		{
+			name:         "fills in a missing rating",
+			importRating: 9,
+			existing:     entity.Watched{GormModel: dbmodel.GormModel{ID: 1}, Rating: 0},
+			wantType:     domain.IMPORT_RATING_UPDATED,
+			wantUpdate:   true,
+			wantRating:   9,
+		},
+		{
+			name:         "does not overwrite an existing rating",
+			importRating: 5,
+			existing:     entity.Watched{GormModel: dbmodel.GormModel{ID: 1}, Rating: 9},
+			wantType:     domain.IMPORT_EXISTS,
+			wantUpdate:   false,
+		},
+		{
+			name:         "import without a rating changes nothing",
+			importRating: 0,
+			existing:     entity.Watched{GormModel: dbmodel.GormModel{ID: 1}, Rating: 0},
+			wantType:     domain.IMPORT_EXISTS,
+			wantUpdate:   false,
+		},
+		{
+			name:         "no existing entry found",
+			importRating: 9,
+			existing:     entity.Watched{},
+			wantType:     domain.IMPORT_EXISTS,
+			wantUpdate:   false,
+		},
+		{
+			name:         "lookup failure is not fatal",
+			importRating: 9,
+			getErr:       errors.New("db exploded"),
+			wantType:     domain.IMPORT_EXISTS,
+			wantUpdate:   false,
+		},
+		{
+			name:         "update failure falls back to exists",
+			importRating: 9,
+			existing:     entity.Watched{GormModel: dbmodel.GormModel{ID: 1}, Rating: 0},
+			updateErr:    errors.New("db exploded"),
+			wantType:     domain.IMPORT_EXISTS,
+			wantUpdate:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeWatchedProvider{
+				existing:  tt.existing,
+				getErr:    tt.getErr,
+				updateErr: tt.updateErr,
+			}
+			s := &Service{wp: fake}
+
+			resp := s.fillInMissingRating(
+				1,
+				&domain.ImportRequest{Rating: tt.importRating},
+				domain.SuccessfulImportProps{
+					TmdbID:      tmdbId,
+					ContentType: util.SupportedMediaShow,
+				},
+			)
+
+			if resp.Type != tt.wantType {
+				t.Fatalf("response type = %q, want %q", resp.Type, tt.wantType)
+			}
+			if tt.wantUpdate {
+				if len(fake.updateCalls) != 1 {
+					t.Fatalf("UpdateWatchedRating calls = %d, want 1", len(fake.updateCalls))
+				}
+				if fake.updateCalls[0].rating != tt.importRating {
+					t.Errorf("updated with rating %v, want %v",
+						fake.updateCalls[0].rating, tt.importRating)
+				}
+				if fake.updateCalls[0].watchedId != tt.existing.ID {
+					t.Errorf("updated watched id %d, want %d",
+						fake.updateCalls[0].watchedId, tt.existing.ID)
+				}
+			} else if len(fake.updateCalls) != 0 {
+				t.Fatalf("UpdateWatchedRating called %d times, want 0 (a rating"+
+					" must not be touched here)", len(fake.updateCalls))
+			}
+			if tt.wantRating != 0 && resp.WatchedEntry.Rating != tt.wantRating {
+				t.Errorf("returned entry rating = %v, want %v",
+					resp.WatchedEntry.Rating, tt.wantRating)
+			}
+		})
+	}
+}
+
+// TestFillInMissingRating_NonTmdbContent checks content that is not looked up
+// by tmdb id (games) is left alone rather than being matched incorrectly.
+func TestFillInMissingRating_NonTmdbContent(t *testing.T) {
+	fake := &fakeWatchedProvider{
+		existing: entity.Watched{GormModel: dbmodel.GormModel{ID: 1}, Rating: 0},
+	}
+	s := &Service{wp: fake}
+
+	resp := s.fillInMissingRating(
+		1,
+		&domain.ImportRequest{Rating: 9},
+		domain.SuccessfulImportProps{
+			IgdbID:      123,
+			ContentType: util.SupportedMediaGame,
+		},
+	)
+
+	if resp.Type != domain.IMPORT_EXISTS {
+		t.Fatalf("response type = %q, want %q", resp.Type, domain.IMPORT_EXISTS)
+	}
+	if len(fake.updateCalls) != 0 {
+		t.Fatalf("UpdateWatchedRating called for a game, want no calls")
+	}
+}

--- a/server/feature/watched/watched.go
+++ b/server/feature/watched/watched.go
@@ -679,6 +679,16 @@ func (s *Service) updateWatched(
 	return domain.WatchedUpdateResponse{NewActivity: addedActivity}, nil
 }
 
+// Update only the rating of an existing watched item.
+//
+// Used by the importer to fill in a rating for content that is already on the
+// users list, eg content added by a Plex or Jellyfin sync, which often has no
+// rating on it.
+func (s *Service) UpdateWatchedRating(userId uint, watchedId uint, rating float64) error {
+	_, err := s.updateWatched(userId, watchedId, domain.WatchedUpdateRequest{Rating: rating})
+	return err
+}
+
 func (s *Service) UpdateWatchedLastViewedSeason(
 	userId uint,
 	id uint,

--- a/src/routes/(app)/import/process/+page.svelte
+++ b/src/routes/(app)/import/process/+page.svelte
@@ -691,6 +691,8 @@
 													<Icon i="close" wh={22} />
 												{:else if l.state === ImportResponseType.IMPORT_EXISTS}
 													<Icon i="check" wh={22} />
+												{:else if l.state === ImportResponseType.IMPORT_RATING_UPDATED}
+													<Icon i="star" wh={22} />
 												{/if}
 											</div>
 										</td>

--- a/src/types.ts
+++ b/src/types.ts
@@ -550,6 +550,7 @@ export enum ImportResponseType {
 	IMPORT_MULTI = "IMPORT_MULTI",
 	IMPORT_NOTFOUND = "IMPORT_NOTFOUND",
 	IMPORT_EXISTS = "IMPORT_EXISTS",
+	IMPORT_RATING_UPDATED = "IMPORT_RATING_UPDATED",
 }
 
 export interface ImportResponse {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

AI Disclosure: Yes I used Claude code, yes I understand the code because I've written Go code before AI was even invented. Go isn't my primary programming language, but I understand enough for this PR.

### Changes made

Importing now checks if an entry has an empty rating. If it does and the import source has a rating, the non-empty rating will be used instead. Existing non-empty ratings are never overwritten.

Added an `IMPORT_RATING_UPDATED` response type when a rating has been updated from an import source.

I've also added tests, you can run the new tests (plus existing tests) with `cd server && go test ./...`

This is tested as working for me, it successfully updates unscored entries from Plex with properly scored values from my MAL list. I deployed a Docker container from my fork containing these changes, you can similarly test it if you'd like, it's found at `ghcr.io/ipkpjersi/watcharr:deploy-rating-updates`

A benefit of this featute is I can watch a show with Plex and import it from Plex automatically via a cronjob I created, and then import the ratings from MAL afterwards (since I also add the show to MAL and add a rating on MAL after watching it).