### PR TITLE
Added saving import mappings

### DIFF
--- a/server/database/db.go
+++ b/server/database/db.go
@@ -66,6 +66,7 @@ func Setup(db *gorm.DB) error {
 		&entity.Game{},
 		&entity.ArrRequest{},
 		&entity.Tag{},
+		&entity.ImportMapping{},
 	)
 	if err != nil {
 		slog.Error("Setup: Auto migration failed.")

--- a/server/database/entity/import_mapping.go
+++ b/server/database/entity/import_mapping.go
@@ -20,10 +20,17 @@ type ImportMapping struct {
 	// match on it.
 	Name string `json:"name" gorm:"not null;uniqueIndex:im_user_to_name_to_type"`
 	// Content type the name was imported as. Part of the key because the
-	// same name can legitimately be both a movie and a show.
+	// same name can legitimately be both a movie and a show. Empty when the
+	// import file didn't say and the user never picked, which only happens
+	// for ignored names.
 	Type string `json:"type" gorm:"not null;uniqueIndex:im_user_to_name_to_type"`
 	// The chosen tmdb id (movies and shows).
 	TmdbID int `json:"tmdbId"`
 	// The chosen igdb id (games).
 	IgdbID int `json:"igdbId"`
+	// Set when the user chose to skip this name rather than match it to
+	// anything. Kept as a mapping rather than thrown away so it shows up
+	// alongside the other saved choices and can be changed later, if the
+	// content turns up in tmdb after all.
+	Ignored bool `json:"ignored"`
 }

--- a/server/database/entity/import_mapping.go
+++ b/server/database/entity/import_mapping.go
@@ -1,0 +1,29 @@
+package entity
+
+import "github.com/sbondCo/Watcharr/database/dbmodel"
+
+// A remembered choice of which content a name from an import file refers to.
+//
+// Import files often only give us a title, and a title on its own can match
+// more than one thing (or nothing exactly), which means the user is asked to
+// pick. Saving that choice means re-importing the same file does not ask
+// again.
+//
+// Mappings are per user, so one users choice can never decide what another
+// users import turns into.
+type ImportMapping struct {
+	dbmodel.GormModel
+	// ID of the user this mapping belongs to.
+	UserID uint `json:"-" gorm:"not null;uniqueIndex:usernameidx"`
+	// The name from the import file, lowercased so lookups are not
+	// case sensitive. The original casing is not needed, we only ever
+	// match on it.
+	Name string `json:"name" gorm:"not null;uniqueIndex:usernameidx"`
+	// Content type the name was imported as. Part of the key because the
+	// same name can legitimately be both a movie and a show.
+	Type string `json:"type" gorm:"not null;uniqueIndex:usernameidx"`
+	// The chosen tmdb id (movies and shows).
+	TmdbID int `json:"tmdbId"`
+	// The chosen igdb id (games).
+	IgdbID int `json:"igdbId"`
+}

--- a/server/database/entity/import_mapping.go
+++ b/server/database/entity/import_mapping.go
@@ -14,14 +14,14 @@ import "github.com/sbondCo/Watcharr/database/dbmodel"
 type ImportMapping struct {
 	dbmodel.GormModel
 	// ID of the user this mapping belongs to.
-	UserID uint `json:"-" gorm:"not null;uniqueIndex:usernameidx"`
+	UserID uint `json:"-" gorm:"not null;uniqueIndex:im_user_to_name_to_type"`
 	// The name from the import file, lowercased so lookups are not
 	// case sensitive. The original casing is not needed, we only ever
 	// match on it.
-	Name string `json:"name" gorm:"not null;uniqueIndex:usernameidx"`
+	Name string `json:"name" gorm:"not null;uniqueIndex:im_user_to_name_to_type"`
 	// Content type the name was imported as. Part of the key because the
 	// same name can legitimately be both a movie and a show.
-	Type string `json:"type" gorm:"not null;uniqueIndex:usernameidx"`
+	Type string `json:"type" gorm:"not null;uniqueIndex:im_user_to_name_to_type"`
 	// The chosen tmdb id (movies and shows).
 	TmdbID int `json:"tmdbId"`
 	// The chosen igdb id (games).

--- a/server/domain/import.go
+++ b/server/domain/import.go
@@ -43,6 +43,8 @@ var (
 	IMPORT_NOTFOUND ImportResponseType = "IMPORT_NOTFOUND"
 	// Item already exists so couldn't import (unique constraint hit when adding)
 	IMPORT_EXISTS ImportResponseType = "IMPORT_EXISTS"
+	// User has chosen to skip this name, now and on any future import
+	IMPORT_IGNORED ImportResponseType = "IMPORT_IGNORED"
 )
 
 type ImportRequest struct {
@@ -67,6 +69,11 @@ type ImportRequest struct {
 	// to pick again. Lets a wrong saved choice be corrected, and allows
 	// re-picking everything when that is what the user wants.
 	IgnoreSavedMatches bool `json:"ignoreSavedMatches"`
+
+	// Don't import this name, now or on any future import. Set when the user
+	// gives up on matching an entry, which saves an ignored mapping instead
+	// of a match.
+	IgnoreThisItem bool `json:"ignoreThisItem"`
 }
 
 // Internal struct given to the SuccessfulImport function.
@@ -93,6 +100,11 @@ func NewSuccessfulImportPropsFromMedia(m *Media) (SuccessfulImportProps, error) 
 type ImportMappingUpdateRequest struct {
 	TmdbID int `json:"tmdbId"`
 	IgdbID int `json:"igdbId"`
+	// Content type of the newly picked content. Only needed for mappings
+	// saved without one (an ignored name the import file gave no type to),
+	// which would otherwise hold an id with nothing to say what it is an id
+	// of. Ignored when empty, so an existing type is never lost.
+	Type ImportContentType `json:"type"`
 }
 
 type ImportResponse struct {

--- a/server/domain/import.go
+++ b/server/domain/import.go
@@ -62,6 +62,11 @@ type ImportRequest struct {
 	WatchedEpisodes  []entity.WatchedEpisode `json:"watchedEpisodes"`
 	WatchedSeason    []entity.WatchedSeason  `json:"watchedSeasons"`
 	Tags             []TagAddRequest         `json:"tags"`
+
+	// Skip any previously saved mapping for this name, so the user is asked
+	// to pick again. Lets a wrong saved choice be corrected, and allows
+	// re-picking everything when that is what the user wants.
+	IgnoreSavedMatches bool `json:"ignoreSavedMatches"`
 }
 
 // Internal struct given to the SuccessfulImport function.
@@ -82,6 +87,12 @@ func NewSuccessfulImportPropsFromMedia(m *Media) (SuccessfulImportProps, error) 
 		return p, errors.New("unsupported content type on media")
 	}
 	return p, nil
+}
+
+// Change which content a saved mapping points at.
+type ImportMappingUpdateRequest struct {
+	TmdbID int `json:"tmdbId"`
+	IgdbID int `json:"igdbId"`
 }
 
 type ImportResponse struct {

--- a/server/feature/imprt/import.go
+++ b/server/feature/imprt/import.go
@@ -78,6 +78,22 @@ func (s *Service) ImportContent(
 ) (domain.ImportResponse, error) {
 	slog.Debug("import: Processing request:", "request", ar)
 
+	// An id in the request means the caller already knows what this is,
+	// either from the import file or because the user has just picked it
+	// out of an IMPORT_MULTI response. Remember it so the same name does
+	// not have to be asked about again.
+	if ar.TmdbID != 0 || ar.IgdbID != 0 {
+		s.saveImportMapping(userId, &ar)
+	} else if ar.IgnoreSavedMatches {
+		slog.Debug("import: Ignoring any saved mapping, as requested", "name", ar.Name)
+	} else if mapping := s.findImportMapping(userId, ar.Name, ar.Type); mapping != nil {
+		// A previous import already settled what this name refers to.
+		slog.Debug("import: Using a saved mapping for name",
+			"name", ar.Name, "tmdb_id", mapping.TmdbID, "igdb_id", mapping.IgdbID)
+		ar.TmdbID = mapping.TmdbID
+		ar.IgdbID = mapping.IgdbID
+	}
+
 	// If we have a TMDB ID given to us, we can go directly to
 	// `SuccessfulImport` and let AddWatched fail if it doesn't exist.
 	if ar.TmdbID != 0 {

--- a/server/feature/imprt/import.go
+++ b/server/feature/imprt/import.go
@@ -89,9 +89,16 @@ func (s *Service) ImportContent(
 	} else if mapping := s.findImportMapping(userId, ar.Name, ar.Type); mapping != nil {
 		// A previous import already settled what this name refers to.
 		slog.Debug("import: Using a saved mapping for name",
-			"name", ar.Name, "tmdb_id", mapping.TmdbID, "igdb_id", mapping.IgdbID)
+			"name", ar.Name, "type", mapping.Type,
+			"tmdb_id", mapping.TmdbID, "igdb_id", mapping.IgdbID)
 		ar.TmdbID = mapping.TmdbID
 		ar.IgdbID = mapping.IgdbID
+		// The id belongs to the type that was picked, which isn't always the
+		// type the import file declared (and the file doesn't always declare
+		// one), so take the type from the mapping too. Without this an entry
+		// the file gave no type to would fall through to a name search and
+		// ask again, despite having a saved choice.
+		ar.Type = domain.ImportContentType(mapping.Type)
 	}
 
 	// If we have a TMDB ID given to us, we can go directly to

--- a/server/feature/imprt/import.go
+++ b/server/feature/imprt/import.go
@@ -78,6 +78,14 @@ func (s *Service) ImportContent(
 ) (domain.ImportResponse, error) {
 	slog.Debug("import: Processing request:", "request", ar)
 
+	if ar.IgnoreThisItem {
+		// The user has given up on matching this name, so nothing is imported
+		// and the decision is saved, ending the prompts for it.
+		slog.Debug("import: Ignoring content, as requested", "name", ar.Name)
+		s.saveIgnoredImportMapping(userId, &ar)
+		return domain.ImportResponse{Type: domain.IMPORT_IGNORED}, nil
+	}
+
 	// An id in the request means the caller already knows what this is,
 	// either from the import file or because the user has just picked it
 	// out of an IMPORT_MULTI response. Remember it so the same name does
@@ -87,6 +95,13 @@ func (s *Service) ImportContent(
 	} else if ar.IgnoreSavedMatches {
 		slog.Debug("import: Ignoring any saved mapping, as requested", "name", ar.Name)
 	} else if mapping := s.findImportMapping(userId, ar.Name, ar.Type); mapping != nil {
+		if mapping.Ignored {
+			// A previous import already settled that this name is to be
+			// skipped.
+			slog.Debug("import: Skipping content, ignored by a saved mapping",
+				"name", ar.Name)
+			return domain.ImportResponse{Type: domain.IMPORT_IGNORED}, nil
+		}
 		// A previous import already settled what this name refers to.
 		slog.Debug("import: Using a saved mapping for name",
 			"name", ar.Name, "type", mapping.Type,

--- a/server/feature/imprt/import_mapping.go
+++ b/server/feature/imprt/import_mapping.go
@@ -1,0 +1,158 @@
+package imprt
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+
+	"github.com/sbondCo/Watcharr/database/entity"
+	"github.com/sbondCo/Watcharr/domain"
+	"gorm.io/gorm"
+)
+
+// Names are matched case insensitively, and with surrounding whitespace
+// ignored, so that trivial differences between two exports of the same list
+// do not cause a second prompt.
+func normalizeMappingName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// Look for a previously saved choice for this name and content type.
+//
+// Returns a nil mapping when there is nothing saved, which is the normal case
+// and not an error.
+func (s *Service) findImportMapping(
+	userId uint,
+	name string,
+	contentType domain.ImportContentType,
+) *entity.ImportMapping {
+	normalized := normalizeMappingName(name)
+	if normalized == "" || contentType == "" {
+		return nil
+	}
+	var mapping entity.ImportMapping
+	res := s.db.
+		Where("user_id = ? AND name = ? AND type = ?", userId, normalized, string(contentType)).
+		Take(&mapping)
+	if res.Error != nil {
+		if !errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			slog.Error("findImportMapping: Lookup failed",
+				"user_id", userId, "name", normalized, "error", res.Error)
+		}
+		return nil
+	}
+	if mapping.TmdbID == 0 && mapping.IgdbID == 0 {
+		// Nothing usable saved, treat it as if we found nothing.
+		return nil
+	}
+	return &mapping
+}
+
+// Remember which content a name was imported as, so a later import of the
+// same name does not have to ask again.
+//
+// A failure to save is logged but never fails the import itself, since the
+// content has already been added by this point and losing a convenience is
+// not worth failing on.
+func (s *Service) saveImportMapping(
+	userId uint,
+	ar *domain.ImportRequest,
+) {
+	normalized := normalizeMappingName(ar.Name)
+	if normalized == "" || ar.Type == "" {
+		return
+	}
+	if ar.TmdbID == 0 && ar.IgdbID == 0 {
+		return
+	}
+	mapping := entity.ImportMapping{
+		UserID: userId,
+		Name:   normalized,
+		Type:   string(ar.Type),
+		TmdbID: ar.TmdbID,
+		IgdbID: ar.IgdbID,
+	}
+	// The user can change their mind about what a name refers to, so an
+	// existing mapping is updated rather than left alone.
+	res := s.db.
+		Where("user_id = ? AND name = ? AND type = ?", userId, normalized, string(ar.Type)).
+		Assign(entity.ImportMapping{TmdbID: ar.TmdbID, IgdbID: ar.IgdbID}).
+		FirstOrCreate(&mapping)
+	if res.Error != nil {
+		slog.Error("saveImportMapping: Failed to save mapping",
+			"user_id", userId, "name", normalized, "error", res.Error)
+		return
+	}
+	slog.Debug("saveImportMapping: Saved mapping",
+		"user_id", userId, "name", normalized, "type", ar.Type,
+		"tmdb_id", ar.TmdbID, "igdb_id", ar.IgdbID)
+}
+
+// All of a users saved mappings, newest first.
+func (s *Service) GetImportMappings(userId uint) ([]entity.ImportMapping, error) {
+	mappings := []entity.ImportMapping{}
+	res := s.db.
+		Where("user_id = ?", userId).
+		Order("name asc").
+		Find(&mappings)
+	if res.Error != nil {
+		slog.Error("GetImportMappings: Failed", "user_id", userId, "error", res.Error)
+		return nil, errors.New("failed to get import mappings")
+	}
+	return mappings, nil
+}
+
+// Point an existing mapping at different content.
+//
+// Scoped by user id as well as mapping id so one user can't edit another
+// users mapping by guessing at ids.
+func (s *Service) UpdateImportMapping(
+	userId uint,
+	mappingId uint,
+	ur domain.ImportMappingUpdateRequest,
+) (entity.ImportMapping, error) {
+	if ur.TmdbID == 0 && ur.IgdbID == 0 {
+		return entity.ImportMapping{}, errors.New("a tmdbId or igdbId must be provided")
+	}
+	var mapping entity.ImportMapping
+	res := s.db.
+		Where("id = ? AND user_id = ?", mappingId, userId).
+		Take(&mapping)
+	if res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return entity.ImportMapping{}, errors.New("mapping does not exist")
+		}
+		slog.Error("UpdateImportMapping: Failed to find mapping",
+			"user_id", userId, "mapping_id", mappingId, "error", res.Error)
+		return entity.ImportMapping{}, errors.New("failed to find mapping")
+	}
+	mapping.TmdbID = ur.TmdbID
+	mapping.IgdbID = ur.IgdbID
+	if res := s.db.Save(&mapping); res.Error != nil {
+		slog.Error("UpdateImportMapping: Failed to save mapping",
+			"user_id", userId, "mapping_id", mappingId, "error", res.Error)
+		return entity.ImportMapping{}, errors.New("failed to save mapping")
+	}
+	slog.Info("UpdateImportMapping: Mapping updated",
+		"user_id", userId, "mapping_id", mappingId,
+		"tmdb_id", mapping.TmdbID, "igdb_id", mapping.IgdbID)
+	return mapping, nil
+}
+
+// Forget a mapping, so the name is searched for again on the next import.
+func (s *Service) DeleteImportMapping(userId uint, mappingId uint) error {
+	res := s.db.
+		Where("id = ? AND user_id = ?", mappingId, userId).
+		Delete(&entity.ImportMapping{})
+	if res.Error != nil {
+		slog.Error("DeleteImportMapping: Failed",
+			"user_id", userId, "mapping_id", mappingId, "error", res.Error)
+		return errors.New("failed to delete mapping")
+	}
+	if res.RowsAffected == 0 {
+		return errors.New("mapping does not exist")
+	}
+	slog.Info("DeleteImportMapping: Mapping deleted",
+		"user_id", userId, "mapping_id", mappingId)
+	return nil
+}

--- a/server/feature/imprt/import_mapping.go
+++ b/server/feature/imprt/import_mapping.go
@@ -161,6 +161,22 @@ func (s *Service) UpdateImportMapping(
 	return mapping, nil
 }
 
+// Forget every saved mapping, so all names are searched for again on the next
+// import. Only ever touches the given users mappings.
+func (s *Service) DeleteAllImportMappings(userId uint) (int64, error) {
+	res := s.db.
+		Where("user_id = ?", userId).
+		Delete(&entity.ImportMapping{})
+	if res.Error != nil {
+		slog.Error("DeleteAllImportMappings: Failed",
+			"user_id", userId, "error", res.Error)
+		return 0, errors.New("failed to delete mappings")
+	}
+	slog.Info("DeleteAllImportMappings: Mappings deleted",
+		"user_id", userId, "num_deleted", res.RowsAffected)
+	return res.RowsAffected, nil
+}
+
 // Forget a mapping, so the name is searched for again on the next import.
 func (s *Service) DeleteImportMapping(userId uint, mappingId uint) error {
 	res := s.db.

--- a/server/feature/imprt/import_mapping.go
+++ b/server/feature/imprt/import_mapping.go
@@ -19,6 +19,13 @@ func normalizeMappingName(name string) string {
 
 // Look for a previously saved choice for this name and content type.
 //
+// The content type is only a preference, not a requirement. Import files
+// don't always say what type an entry is (a MyAnimeList export gives OVA,
+// ONA and Special entries a type we have no equivalent for, so they arrive
+// with no type at all), and the type the user picked can differ from the one
+// the file declared. In both of those cases the name on its own is enough,
+// as long as only one saved choice uses it.
+//
 // Returns a nil mapping when there is nothing saved, which is the normal case
 // and not an error.
 func (s *Service) findImportMapping(
@@ -27,25 +34,40 @@ func (s *Service) findImportMapping(
 	contentType domain.ImportContentType,
 ) *entity.ImportMapping {
 	normalized := normalizeMappingName(name)
-	if normalized == "" || contentType == "" {
+	if normalized == "" {
 		return nil
 	}
-	var mapping entity.ImportMapping
+	var mappings []entity.ImportMapping
 	res := s.db.
-		Where("user_id = ? AND name = ? AND type = ?", userId, normalized, string(contentType)).
-		Take(&mapping)
+		Where("user_id = ? AND name = ?", userId, normalized).
+		Find(&mappings)
 	if res.Error != nil {
-		if !errors.Is(res.Error, gorm.ErrRecordNotFound) {
-			slog.Error("findImportMapping: Lookup failed",
-				"user_id", userId, "name", normalized, "error", res.Error)
+		slog.Error("findImportMapping: Lookup failed",
+			"user_id", userId, "name", normalized, "error", res.Error)
+		return nil
+	}
+	// Mappings with nothing usable saved are treated as if they aren't there,
+	// including when deciding whether the name is ambiguous.
+	usable := []entity.ImportMapping{}
+	for _, m := range mappings {
+		if m.TmdbID != 0 || m.IgdbID != 0 {
+			usable = append(usable, m)
 		}
-		return nil
 	}
-	if mapping.TmdbID == 0 && mapping.IgdbID == 0 {
-		// Nothing usable saved, treat it as if we found nothing.
-		return nil
+	// A mapping saved for this exact type is always the best answer.
+	if contentType != "" {
+		for i := range usable {
+			if usable[i].Type == string(contentType) {
+				return &usable[i]
+			}
+		}
 	}
-	return &mapping
+	// Otherwise the name alone decides, but only while it can't mean more
+	// than one thing.
+	if len(usable) == 1 {
+		return &usable[0]
+	}
+	return nil
 }
 
 // Remember which content a name was imported as, so a later import of the

--- a/server/feature/imprt/import_mapping.go
+++ b/server/feature/imprt/import_mapping.go
@@ -17,7 +17,8 @@ func normalizeMappingName(name string) string {
 	return strings.ToLower(strings.TrimSpace(name))
 }
 
-// Look for a previously saved choice for this name and content type.
+// Look for a previously saved choice for this name and content type. The
+// choice can be a match to some content, or a decision to ignore the name.
 //
 // The content type is only a preference, not a requirement. Import files
 // don't always say what type an entry is (a MyAnimeList export gives OVA,
@@ -47,10 +48,12 @@ func (s *Service) findImportMapping(
 		return nil
 	}
 	// Mappings with nothing usable saved are treated as if they aren't there,
-	// including when deciding whether the name is ambiguous.
+	// including when deciding whether the name is ambiguous. An ignored
+	// mapping is usable despite having no ids, its answer is just that there
+	// is nothing to import.
 	usable := []entity.ImportMapping{}
 	for _, m := range mappings {
-		if m.TmdbID != 0 || m.IgdbID != 0 {
+		if m.Ignored || m.TmdbID != 0 || m.IgdbID != 0 {
 			usable = append(usable, m)
 		}
 	}
@@ -87,27 +90,62 @@ func (s *Service) saveImportMapping(
 	if ar.TmdbID == 0 && ar.IgdbID == 0 {
 		return
 	}
-	mapping := entity.ImportMapping{
+	s.upsertImportMapping(userId, entity.ImportMapping{
 		UserID: userId,
 		Name:   normalized,
 		Type:   string(ar.Type),
 		TmdbID: ar.TmdbID,
 		IgdbID: ar.IgdbID,
-	}
-	// The user can change their mind about what a name refers to, so an
-	// existing mapping is updated rather than left alone.
-	res := s.db.
-		Where("user_id = ? AND name = ? AND type = ?", userId, normalized, string(ar.Type)).
-		Assign(entity.ImportMapping{TmdbID: ar.TmdbID, IgdbID: ar.IgdbID}).
-		FirstOrCreate(&mapping)
-	if res.Error != nil {
-		slog.Error("saveImportMapping: Failed to save mapping",
-			"user_id", userId, "name", normalized, "error", res.Error)
+	})
+}
+
+// Remember that a name should be skipped, so later imports of the same name
+// do not ask about it again.
+//
+// Unlike a match, this is saved even when the import file gave no content
+// type, since the entries a user gives up on matching are often the ones we
+// have no type for.
+func (s *Service) saveIgnoredImportMapping(
+	userId uint,
+	ar *domain.ImportRequest,
+) {
+	normalized := normalizeMappingName(ar.Name)
+	if normalized == "" {
 		return
 	}
-	slog.Debug("saveImportMapping: Saved mapping",
-		"user_id", userId, "name", normalized, "type", ar.Type,
-		"tmdb_id", ar.TmdbID, "igdb_id", ar.IgdbID)
+	s.upsertImportMapping(userId, entity.ImportMapping{
+		UserID:  userId,
+		Name:    normalized,
+		Type:    string(ar.Type),
+		Ignored: true,
+	})
+}
+
+// Write a mapping, replacing whatever was saved for the same name and type.
+//
+// The user can change their mind about what a name refers to, so an existing
+// mapping is updated rather than left alone.
+func (s *Service) upsertImportMapping(userId uint, mapping entity.ImportMapping) {
+	res := s.db.
+		Where("user_id = ? AND name = ? AND type = ?", userId, mapping.Name, mapping.Type).
+		// Assigned as a map rather than a struct so that clearing a field
+		// back to its zero value sticks, which gorm skips for struct
+		// updates. Un-ignoring a name by matching it depends on it.
+		Assign(map[string]any{
+			"tmdb_id": mapping.TmdbID,
+			"igdb_id": mapping.IgdbID,
+			"ignored": mapping.Ignored,
+		}).
+		FirstOrCreate(&mapping)
+	if res.Error != nil {
+		slog.Error("upsertImportMapping: Failed to save mapping",
+			"user_id", userId, "name", mapping.Name, "error", res.Error)
+		return
+	}
+	slog.Debug("upsertImportMapping: Saved mapping",
+		"user_id", userId, "name", mapping.Name, "type", mapping.Type,
+		"tmdb_id", mapping.TmdbID, "igdb_id", mapping.IgdbID,
+		"ignored", mapping.Ignored)
 }
 
 // All of a users saved mappings, newest first.
@@ -150,6 +188,15 @@ func (s *Service) UpdateImportMapping(
 	}
 	mapping.TmdbID = ur.TmdbID
 	mapping.IgdbID = ur.IgdbID
+	// Pointing a mapping at real content is also how an ignored name is
+	// un-ignored.
+	mapping.Ignored = false
+	// An ignored name can have been saved with no type, which would leave the
+	// new id with nothing to say what it is an id of, so the picked type is
+	// taken when the mapping has none of its own.
+	if mapping.Type == "" && ur.Type != "" {
+		mapping.Type = string(ur.Type)
+	}
 	if res := s.db.Save(&mapping); res.Error != nil {
 		slog.Error("UpdateImportMapping: Failed to save mapping",
 			"user_id", userId, "mapping_id", mappingId, "error", res.Error)
@@ -164,7 +211,11 @@ func (s *Service) UpdateImportMapping(
 // Forget every saved mapping, so all names are searched for again on the next
 // import. Only ever touches the given users mappings.
 func (s *Service) DeleteAllImportMappings(userId uint) (int64, error) {
+	// Deleted outright rather than soft deleted. A soft deleted row still
+	// occupies its spot in the unique index, so saving the same name again
+	// afterwards would fail, and a forgotten choice is not worth keeping.
 	res := s.db.
+		Unscoped().
 		Where("user_id = ?", userId).
 		Delete(&entity.ImportMapping{})
 	if res.Error != nil {
@@ -179,7 +230,9 @@ func (s *Service) DeleteAllImportMappings(userId uint) (int64, error) {
 
 // Forget a mapping, so the name is searched for again on the next import.
 func (s *Service) DeleteImportMapping(userId uint, mappingId uint) error {
+	// Deleted outright, for the reason given in DeleteAllImportMappings.
 	res := s.db.
+		Unscoped().
 		Where("id = ? AND user_id = ?", mappingId, userId).
 		Delete(&entity.ImportMapping{})
 	if res.Error != nil {

--- a/server/feature/imprt/import_mapping_test.go
+++ b/server/feature/imprt/import_mapping_test.go
@@ -131,6 +131,147 @@ func TestImportMappingWhenImportFileHasNoType(t *testing.T) {
 	})
 }
 
+// TestIgnoredImportMapping checks a name the user gave up on is remembered as
+// ignored, including when the import file never said what type it was, and
+// that matching it later takes the ignore back off.
+func TestIgnoredImportMapping(t *testing.T) {
+	testutil.SetupLogging()
+	s := &Service{db: testutil.SetupDB(t)}
+
+	const userId = 1
+	const otherUserId = 2
+
+	// The entries a user gives up on are often the ones we have no type for,
+	// so an ignore is saved without one.
+	s.saveIgnoredImportMapping(userId, &domain.ImportRequest{
+		Name: "Asagao to Kase-san.",
+	})
+
+	t.Run("ignored name is found", func(t *testing.T) {
+		m := s.findImportMapping(userId, "Asagao to Kase-san.", "")
+		if m == nil {
+			t.Fatal("ignored mapping was not found")
+		}
+		if !m.Ignored {
+			t.Error("mapping was not marked as ignored")
+		}
+	})
+
+	t.Run("ignored name is found for a typed import too", func(t *testing.T) {
+		m := s.findImportMapping(userId, "Asagao to Kase-san.", domain.ImportContentTypeMovie)
+		if m == nil || !m.Ignored {
+			t.Fatalf("ignored mapping = %v, want an ignored mapping", m)
+		}
+	})
+
+	t.Run("another users import is not ignored", func(t *testing.T) {
+		if m := s.findImportMapping(otherUserId, "Asagao to Kase-san.", ""); m != nil {
+			t.Fatal("found another users ignored mapping, mappings must be per user")
+		}
+	})
+
+	t.Run("ignoring twice does not create a second mapping", func(t *testing.T) {
+		s.saveIgnoredImportMapping(userId, &domain.ImportRequest{
+			Name: "asagao to kase-san.",
+		})
+		mappings, err := s.GetImportMappings(userId)
+		if err != nil {
+			t.Fatalf("failed to list mappings: %v", err)
+		}
+		if len(mappings) != 1 {
+			t.Fatalf("got %d mappings, want 1", len(mappings))
+		}
+	})
+
+	t.Run("matching an ignored name stops it being ignored", func(t *testing.T) {
+		mappings, err := s.GetImportMappings(userId)
+		if err != nil {
+			t.Fatalf("failed to list mappings: %v", err)
+		}
+		updated, err := s.UpdateImportMapping(userId, mappings[0].ID, domain.ImportMappingUpdateRequest{
+			TmdbID: 515295,
+			Type:   domain.ImportContentTypeMovie,
+		})
+		if err != nil {
+			t.Fatalf("failed to update mapping: %v", err)
+		}
+		if updated.Ignored {
+			t.Error("mapping is still ignored after being pointed at content")
+		}
+		// The type comes from the pick, since the ignore had none, otherwise
+		// the id would have nothing saying what it is an id of.
+		if updated.Type != string(domain.ImportContentTypeMovie) {
+			t.Errorf("type = %q, want %q", updated.Type, domain.ImportContentTypeMovie)
+		}
+		m := s.findImportMapping(userId, "Asagao to Kase-san.", "")
+		if m == nil || m.Ignored || m.TmdbID != 515295 {
+			t.Fatalf("mapping = %v, want an unignored mapping for tmdb 515295", m)
+		}
+	})
+}
+
+// TestImportContentIgnores checks the import itself skips content the user
+// has given up on, both when they ask for it and on every import after that.
+//
+// Both paths return before any content is searched for or added, so the
+// service needs nothing but a database here.
+func TestImportContentIgnores(t *testing.T) {
+	testutil.SetupLogging()
+	s := &Service{db: testutil.SetupDB(t)}
+
+	const userId = 1
+
+	resp, err := s.ImportContent(userId, domain.ImportRequest{
+		Name:           "Ame to Kimi to",
+		IgnoreThisItem: true,
+	})
+	if err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+	if resp.Type != domain.IMPORT_IGNORED {
+		t.Errorf("response type = %q, want %q", resp.Type, domain.IMPORT_IGNORED)
+	}
+
+	// The next import of the same name is skipped without asking again.
+	resp, err = s.ImportContent(userId, domain.ImportRequest{Name: "Ame to Kimi to"})
+	if err != nil {
+		t.Fatalf("second import failed: %v", err)
+	}
+	if resp.Type != domain.IMPORT_IGNORED {
+		t.Errorf("second response type = %q, want %q", resp.Type, domain.IMPORT_IGNORED)
+	}
+}
+
+// TestSaveImportMappingUnignores checks that importing a name for real, after
+// it was ignored, replaces the ignore rather than being blocked by it.
+func TestSaveImportMappingUnignores(t *testing.T) {
+	testutil.SetupLogging()
+	s := &Service{db: testutil.SetupDB(t)}
+
+	const userId = 1
+
+	s.saveIgnoredImportMapping(userId, &domain.ImportRequest{
+		Name: "Kanon",
+		Type: domain.ImportContentTypeShow,
+	})
+	s.saveImportMapping(userId, &domain.ImportRequest{
+		Name:   "Kanon",
+		Type:   domain.ImportContentTypeShow,
+		TmdbID: 72540,
+	})
+
+	m := s.findImportMapping(userId, "Kanon", domain.ImportContentTypeShow)
+	if m == nil {
+		t.Fatal("mapping was not found")
+	}
+	if m.Ignored {
+		t.Error("mapping is still ignored after the name was imported")
+	}
+	if m.TmdbID != 72540 {
+		t.Errorf("tmdb id = %d, want 72540", m.TmdbID)
+	}
+}
+
 // TestImportMappingIsUpdated checks that changing your mind about what a name
 // refers to replaces the old choice rather than leaving it in place or
 // creating a second row.

--- a/server/feature/imprt/import_mapping_test.go
+++ b/server/feature/imprt/import_mapping_test.go
@@ -1,0 +1,237 @@
+package imprt
+
+import (
+	"testing"
+
+	"github.com/sbondCo/Watcharr/domain"
+	"github.com/sbondCo/Watcharr/internal/testutil"
+)
+
+// TestImportMappingRoundTrip checks a choice saved for one name is found
+// again for that same name, and that near misses (different user, different
+// content type, unknown name) do not match it.
+func TestImportMappingRoundTrip(t *testing.T) {
+	testutil.SetupLogging()
+	s := &Service{db: testutil.SetupDB(t)}
+
+	const userId = 1
+	const otherUserId = 2
+
+	s.saveImportMapping(userId, &domain.ImportRequest{
+		Name:   "Oshi no Ko",
+		Type:   domain.ImportContentTypeShow,
+		TmdbID: 203737,
+	})
+
+	t.Run("same name is found", func(t *testing.T) {
+		m := s.findImportMapping(userId, "Oshi no Ko", domain.ImportContentTypeShow)
+		if m == nil {
+			t.Fatal("saved mapping was not found")
+		}
+		if m.TmdbID != 203737 {
+			t.Errorf("tmdb id = %d, want 203737", m.TmdbID)
+		}
+	})
+
+	t.Run("matching ignores case and surrounding whitespace", func(t *testing.T) {
+		m := s.findImportMapping(userId, "  oShI No KO  ", domain.ImportContentTypeShow)
+		if m == nil {
+			t.Fatal("mapping was not found for a differently cased name")
+		}
+		if m.TmdbID != 203737 {
+			t.Errorf("tmdb id = %d, want 203737", m.TmdbID)
+		}
+	})
+
+	t.Run("another users mapping is not used", func(t *testing.T) {
+		if m := s.findImportMapping(otherUserId, "Oshi no Ko", domain.ImportContentTypeShow); m != nil {
+			t.Fatalf("found another users mapping (tmdb %d), mappings must be per user", m.TmdbID)
+		}
+	})
+
+	t.Run("same name as a different content type is not used", func(t *testing.T) {
+		if m := s.findImportMapping(userId, "Oshi no Ko", domain.ImportContentTypeMovie); m != nil {
+			t.Fatalf("show mapping was returned for a movie import (tmdb %d)", m.TmdbID)
+		}
+	})
+
+	t.Run("unknown name returns nothing", func(t *testing.T) {
+		if m := s.findImportMapping(userId, "Some Other Show", domain.ImportContentTypeShow); m != nil {
+			t.Fatalf("found a mapping for a name that was never saved (tmdb %d)", m.TmdbID)
+		}
+	})
+}
+
+// TestImportMappingIsUpdated checks that changing your mind about what a name
+// refers to replaces the old choice rather than leaving it in place or
+// creating a second row.
+func TestImportMappingIsUpdated(t *testing.T) {
+	testutil.SetupLogging()
+	s := &Service{db: testutil.SetupDB(t)}
+
+	const userId = 1
+	req := domain.ImportRequest{
+		Name:   "Oshi no Ko",
+		Type:   domain.ImportContentTypeShow,
+		TmdbID: 203737,
+	}
+	s.saveImportMapping(userId, &req)
+
+	req.TmdbID = 244377
+	s.saveImportMapping(userId, &req)
+
+	m := s.findImportMapping(userId, "Oshi no Ko", domain.ImportContentTypeShow)
+	if m == nil {
+		t.Fatal("mapping was not found after being updated")
+	}
+	if m.TmdbID != 244377 {
+		t.Errorf("tmdb id = %d, want 244377 (the newer choice)", m.TmdbID)
+	}
+
+	var count int64
+	s.db.Table("import_mappings").
+		Where("user_id = ? AND name = ?", userId, "oshi no ko").
+		Count(&count)
+	if count != 1 {
+		t.Errorf("stored rows = %d, want 1 (updating must not add a row)", count)
+	}
+}
+
+// TestSaveImportMappingIgnoresUnusableRequests checks we do not store rows we
+// could never match on later.
+func TestSaveImportMappingIgnoresUnusableRequests(t *testing.T) {
+	testutil.SetupLogging()
+	s := &Service{db: testutil.SetupDB(t)}
+
+	const userId = 1
+
+	tests := []struct {
+		name string
+		req  domain.ImportRequest
+	}{
+		{
+			name: "no name to key on",
+			req:  domain.ImportRequest{Type: domain.ImportContentTypeShow, TmdbID: 203737},
+		},
+		{
+			name: "no content type to key on",
+			req:  domain.ImportRequest{Name: "Oshi no Ko", TmdbID: 203737},
+		},
+		{
+			name: "no id worth remembering",
+			req:  domain.ImportRequest{Name: "Oshi no Ko", Type: domain.ImportContentTypeShow},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s.saveImportMapping(userId, &tt.req)
+			var count int64
+			s.db.Table("import_mappings").Count(&count)
+			if count != 0 {
+				t.Fatalf("stored %d mappings, want 0", count)
+			}
+		})
+	}
+}
+
+// TestImportMappingCRUD covers the endpoints behind the mappings page:
+// listing, repointing at different content, and forgetting. Each is scoped
+// by user id, so one user cannot read or change another users mappings.
+func TestImportMappingCRUD(t *testing.T) {
+	testutil.SetupLogging()
+	s := &Service{db: testutil.SetupDB(t)}
+
+	const userId = 1
+	const otherUserId = 2
+
+	s.saveImportMapping(userId, &domain.ImportRequest{
+		Name: "Oshi no Ko", Type: domain.ImportContentTypeShow, TmdbID: 203737,
+	})
+	s.saveImportMapping(userId, &domain.ImportRequest{
+		Name: "Bleach", Type: domain.ImportContentTypeShow, TmdbID: 30984,
+	})
+	s.saveImportMapping(otherUserId, &domain.ImportRequest{
+		Name: "Someone Elses Show", Type: domain.ImportContentTypeShow, TmdbID: 111,
+	})
+
+	t.Run("list only returns our own mappings", func(t *testing.T) {
+		got, err := s.GetImportMappings(userId)
+		if err != nil {
+			t.Fatalf("GetImportMappings failed: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("returned %d mappings, want 2", len(got))
+		}
+		for _, m := range got {
+			if m.UserID != userId {
+				t.Errorf("returned a mapping owned by user %d", m.UserID)
+			}
+		}
+	})
+
+	t.Run("update repoints the mapping", func(t *testing.T) {
+		list, _ := s.GetImportMappings(userId)
+		target := list[0]
+		updated, err := s.UpdateImportMapping(userId, target.ID,
+			domain.ImportMappingUpdateRequest{TmdbID: 999})
+		if err != nil {
+			t.Fatalf("UpdateImportMapping failed: %v", err)
+		}
+		if updated.TmdbID != 999 {
+			t.Errorf("tmdb id = %d, want 999", updated.TmdbID)
+		}
+		found := s.findImportMapping(userId, target.Name, domain.ImportContentType(target.Type))
+		if found == nil || found.TmdbID != 999 {
+			t.Errorf("lookup after update did not return the new id")
+		}
+	})
+
+	t.Run("update requires an id to point at", func(t *testing.T) {
+		list, _ := s.GetImportMappings(userId)
+		if _, err := s.UpdateImportMapping(userId, list[0].ID,
+			domain.ImportMappingUpdateRequest{}); err == nil {
+			t.Error("expected an error when no tmdbId or igdbId is given")
+		}
+	})
+
+	t.Run("cannot update another users mapping", func(t *testing.T) {
+		otherList, _ := s.GetImportMappings(otherUserId)
+		if _, err := s.UpdateImportMapping(userId, otherList[0].ID,
+			domain.ImportMappingUpdateRequest{TmdbID: 5}); err == nil {
+			t.Fatal("was allowed to update another users mapping")
+		}
+		still, _ := s.GetImportMappings(otherUserId)
+		if still[0].TmdbID != 111 {
+			t.Errorf("another users mapping was changed to %d", still[0].TmdbID)
+		}
+	})
+
+	t.Run("cannot delete another users mapping", func(t *testing.T) {
+		otherList, _ := s.GetImportMappings(otherUserId)
+		if err := s.DeleteImportMapping(userId, otherList[0].ID); err == nil {
+			t.Fatal("was allowed to delete another users mapping")
+		}
+		still, _ := s.GetImportMappings(otherUserId)
+		if len(still) != 1 {
+			t.Errorf("another users mappings now number %d, want 1", len(still))
+		}
+	})
+
+	t.Run("delete forgets the mapping", func(t *testing.T) {
+		list, _ := s.GetImportMappings(userId)
+		target := list[0]
+		if err := s.DeleteImportMapping(userId, target.ID); err != nil {
+			t.Fatalf("DeleteImportMapping failed: %v", err)
+		}
+		if m := s.findImportMapping(userId, target.Name, domain.ImportContentType(target.Type)); m != nil {
+			t.Error("mapping was still found after being deleted")
+		}
+	})
+
+	t.Run("deleting a mapping that does not exist errors", func(t *testing.T) {
+		if err := s.DeleteImportMapping(userId, 99999); err == nil {
+			t.Error("expected an error deleting a non existent mapping")
+		}
+	})
+}

--- a/server/feature/imprt/import_mapping_test.go
+++ b/server/feature/imprt/import_mapping_test.go
@@ -49,15 +49,84 @@ func TestImportMappingRoundTrip(t *testing.T) {
 		}
 	})
 
-	t.Run("same name as a different content type is not used", func(t *testing.T) {
-		if m := s.findImportMapping(userId, "Oshi no Ko", domain.ImportContentTypeMovie); m != nil {
-			t.Fatalf("show mapping was returned for a movie import (tmdb %d)", m.TmdbID)
+	t.Run("same name as a different content type keeps its own mapping", func(t *testing.T) {
+		s.saveImportMapping(userId, &domain.ImportRequest{
+			Name:   "Oshi no Ko",
+			Type:   domain.ImportContentTypeMovie,
+			TmdbID: 1114894,
+		})
+		m := s.findImportMapping(userId, "Oshi no Ko", domain.ImportContentTypeMovie)
+		if m == nil {
+			t.Fatal("movie mapping was not found")
+		}
+		if m.TmdbID != 1114894 {
+			t.Errorf("tmdb id = %d, want 1114894 (the movie, not the show)", m.TmdbID)
 		}
 	})
 
 	t.Run("unknown name returns nothing", func(t *testing.T) {
 		if m := s.findImportMapping(userId, "Some Other Show", domain.ImportContentTypeShow); m != nil {
 			t.Fatalf("found a mapping for a name that was never saved (tmdb %d)", m.TmdbID)
+		}
+	})
+}
+
+// TestImportMappingWhenImportFileHasNoType checks the case an import file
+// gives us an entry with no type we recognise (MyAnimeList exports do this
+// for OVA, ONA and Special entries), so the saved choice is looked for with
+// no type to match on.
+func TestImportMappingWhenImportFileHasNoType(t *testing.T) {
+	testutil.SetupLogging()
+	s := &Service{db: testutil.SetupDB(t)}
+
+	const userId = 1
+
+	// The type saved is the type of the content the user picked, which the
+	// import file never told us about.
+	s.saveImportMapping(userId, &domain.ImportRequest{
+		Name:   "Aa! Megami-sama!",
+		Type:   domain.ImportContentTypeShow,
+		TmdbID: 29117,
+	})
+
+	t.Run("untyped import finds the mapping", func(t *testing.T) {
+		m := s.findImportMapping(userId, "Aa! Megami-sama!", "")
+		if m == nil {
+			t.Fatal("mapping was not found for an import entry with no type")
+		}
+		if m.TmdbID != 29117 {
+			t.Errorf("tmdb id = %d, want 29117", m.TmdbID)
+		}
+	})
+
+	t.Run("import typed differently to the pick finds the mapping", func(t *testing.T) {
+		m := s.findImportMapping(userId, "Aa! Megami-sama!", domain.ImportContentTypeMovie)
+		if m == nil {
+			t.Fatal("mapping was not found when the file type differed from the picked type")
+		}
+		if m.TmdbID != 29117 {
+			t.Errorf("tmdb id = %d, want 29117", m.TmdbID)
+		}
+	})
+
+	t.Run("an ambiguous name is not guessed at", func(t *testing.T) {
+		// Same name saved as a movie too, so the name alone no longer says
+		// which content is meant.
+		s.saveImportMapping(userId, &domain.ImportRequest{
+			Name:   "Aa! Megami-sama!",
+			Type:   domain.ImportContentTypeMovie,
+			TmdbID: 12345,
+		})
+
+		if m := s.findImportMapping(userId, "Aa! Megami-sama!", ""); m != nil {
+			t.Fatalf("a mapping (tmdb %d) was used for a name meaning more than one thing", m.TmdbID)
+		}
+		// Each type still finds its own mapping.
+		if m := s.findImportMapping(userId, "Aa! Megami-sama!", domain.ImportContentTypeShow); m == nil || m.TmdbID != 29117 {
+			t.Errorf("show mapping = %v, want tmdb 29117", m)
+		}
+		if m := s.findImportMapping(userId, "Aa! Megami-sama!", domain.ImportContentTypeMovie); m == nil || m.TmdbID != 12345 {
+			t.Errorf("movie mapping = %v, want tmdb 12345", m)
 		}
 	})
 }
@@ -232,6 +301,35 @@ func TestImportMappingCRUD(t *testing.T) {
 	t.Run("deleting a mapping that does not exist errors", func(t *testing.T) {
 		if err := s.DeleteImportMapping(userId, 99999); err == nil {
 			t.Error("expected an error deleting a non existent mapping")
+		}
+	})
+
+	t.Run("delete all forgets only our own mappings", func(t *testing.T) {
+		numDeleted, err := s.DeleteAllImportMappings(userId)
+		if err != nil {
+			t.Fatalf("DeleteAllImportMappings failed: %v", err)
+		}
+		ours, _ := s.GetImportMappings(userId)
+		if len(ours) != 0 {
+			t.Errorf("we still have %d mappings, want 0", len(ours))
+		}
+		if numDeleted != 1 {
+			// One of ours was already deleted by an earlier subtest.
+			t.Errorf("reported %d deleted, want 1", numDeleted)
+		}
+		theirs, _ := s.GetImportMappings(otherUserId)
+		if len(theirs) != 1 {
+			t.Errorf("another users mappings now number %d, want 1", len(theirs))
+		}
+	})
+
+	t.Run("delete all with nothing saved is not an error", func(t *testing.T) {
+		numDeleted, err := s.DeleteAllImportMappings(userId)
+		if err != nil {
+			t.Fatalf("DeleteAllImportMappings failed: %v", err)
+		}
+		if numDeleted != 0 {
+			t.Errorf("reported %d deleted, want 0", numDeleted)
 		}
 	})
 }

--- a/server/feature/imprt/router.go
+++ b/server/feature/imprt/router.go
@@ -33,6 +33,7 @@ func (r *Router) AddRoutes() {
 	// Saved choices of what a name from an import file refers to.
 	imprt.GET("/mappings", r.GetImportMappings)
 	imprt.PUT("/mappings/:id", r.UpdateImportMapping)
+	imprt.DELETE("/mappings", r.DeleteAllImportMappings)
 	imprt.DELETE("/mappings/:id", r.DeleteImportMapping)
 }
 
@@ -66,6 +67,17 @@ func (r *Router) UpdateImportMapping(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, mapping)
+}
+
+// Forget all of our saved import mappings.
+func (r *Router) DeleteAllImportMappings(c *gin.Context) {
+	userId := c.MustGet("userId").(uint)
+	numDeleted, err := r.service.DeleteAllImportMappings(userId)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, router.ErrorResponse{Error: err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"numDeleted": numDeleted})
 }
 
 // Forget a saved import mapping.

--- a/server/feature/imprt/router.go
+++ b/server/feature/imprt/router.go
@@ -2,6 +2,7 @@ package imprt
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sbondCo/Watcharr/domain"
@@ -28,6 +29,58 @@ func (r *Router) AddRoutes() {
 
 	imprt.POST("", r.ImportContent)
 	imprt.POST("/trakt", r.ImportTrakt)
+
+	// Saved choices of what a name from an import file refers to.
+	imprt.GET("/mappings", r.GetImportMappings)
+	imprt.PUT("/mappings/:id", r.UpdateImportMapping)
+	imprt.DELETE("/mappings/:id", r.DeleteImportMapping)
+}
+
+// Get all of our saved import mappings.
+func (r *Router) GetImportMappings(c *gin.Context) {
+	userId := c.MustGet("userId").(uint)
+	mappings, err := r.service.GetImportMappings(userId)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, router.ErrorResponse{Error: err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, mappings)
+}
+
+// Point a saved import mapping at different content.
+func (r *Router) UpdateImportMapping(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+	userId := c.MustGet("userId").(uint)
+	var ur domain.ImportMappingUpdateRequest
+	if err := c.ShouldBindJSON(&ur); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, router.ErrorResponse{Error: err.Error()})
+		return
+	}
+	mapping, err := r.service.UpdateImportMapping(userId, uint(id), ur)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, router.ErrorResponse{Error: err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, mapping)
+}
+
+// Forget a saved import mapping.
+func (r *Router) DeleteImportMapping(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+	userId := c.MustGet("userId").(uint)
+	if err := r.service.DeleteImportMapping(userId, uint(id)); err != nil {
+		c.JSON(http.StatusBadRequest, router.ErrorResponse{Error: err.Error()})
+		return
+	}
+	c.Status(http.StatusOK)
 }
 
 // Import content (the client handle processing data and sends it to us in a uniform way).

--- a/src/routes/(app)/import/+page.svelte
+++ b/src/routes/(app)/import/+page.svelte
@@ -751,19 +751,25 @@
 					filesSelected={(f) => processTodoMoviesFile(f)}
 				/>
 
-				<a class="mappings-link" href="/import/mappings">
-					View saved import matches
-				</a>
+				<div class="mappings-btn">
+					<button onclick={() => goto(resolve("/import/mappings"))}>
+						View saved import matches
+					</button>
+				</div>
 			{/if}
 		</div>
 	</div>
 </div>
 
 <style lang="scss">
-	.mappings-link {
+	.mappings-btn {
+		display: flex;
+		justify-content: center;
 		margin-top: 15px;
-		font-size: 14px;
-		text-align: center;
+
+		button {
+			width: max-content;
+		}
 	}
 
 	.content {

--- a/src/routes/(app)/import/+page.svelte
+++ b/src/routes/(app)/import/+page.svelte
@@ -750,12 +750,22 @@
 					text="TodoMovies"
 					filesSelected={(f) => processTodoMoviesFile(f)}
 				/>
+
+				<a class="mappings-link" href="/import/mappings">
+					View saved import matches
+				</a>
 			{/if}
 		</div>
 	</div>
 </div>
 
 <style lang="scss">
+	.mappings-link {
+		margin-top: 15px;
+		font-size: 14px;
+		text-align: center;
+	}
+
 	.content {
 		display: flex;
 		width: 100%;

--- a/src/routes/(app)/import/mappings/+page.svelte
+++ b/src/routes/(app)/import/mappings/+page.svelte
@@ -1,0 +1,306 @@
+<script lang="ts">
+	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
+	import Icon from "@/lib/Icon.svelte";
+	import Modal from "@/lib/Modal.svelte";
+	import Poster from "@/lib/poster/Poster.svelte";
+	import PosterList from "@/lib/poster/PosterList.svelte";
+	import Spinner from "@/lib/Spinner.svelte";
+	import SpinnerTiny from "@/lib/SpinnerTiny.svelte";
+	import { req } from "@/lib/util/api";
+	import { notify } from "@/lib/util/notify";
+	import type { Media, ImportMapping } from "@/types";
+
+	let mappings: ImportMapping[] = $state([]);
+	let isLoading = $state(true);
+	let loadError = $state("");
+
+	// The mapping currently being repointed at different content, if any.
+	let changing: ImportMapping | undefined = $state(undefined);
+	let searchQuery = $state("");
+	let searchResults: Media[] = $state([]);
+	let isSearching = $state(false);
+	// Ids of mappings with a request in flight, so their buttons can be
+	// disabled individually rather than locking the whole page.
+	let busyIds: number[] = $state([]);
+
+	async function load() {
+		isLoading = true;
+		loadError = "";
+		try {
+			mappings = await req.get<ImportMapping[]>("/import/mappings");
+		} catch (err) {
+			console.error("mappings: failed to load", err);
+			loadError = "Couldn't load your saved matches.";
+		}
+		isLoading = false;
+	}
+
+	load();
+
+	function contentLink(m: ImportMapping): string | undefined {
+		if (m.tmdbId) {
+			return m.type === "movie" ? `/movie/${m.tmdbId}` : `/tv/${m.tmdbId}`;
+		}
+		if (m.igdbId) {
+			return `/game/${m.igdbId}`;
+		}
+		return undefined;
+	}
+
+	async function forget(m: ImportMapping) {
+		busyIds = [...busyIds, m.id];
+		try {
+			await req.delete(`/import/mappings/${m.id}`);
+			mappings = mappings.filter((x) => x.id !== m.id);
+			notify({ type: "success", text: `Forgot the match for ${m.name}` });
+		} catch (err) {
+			console.error("mappings: failed to forget", err);
+			notify({ type: "error", text: `Couldn't forget the match for ${m.name}` });
+		}
+		busyIds = busyIds.filter((id) => id !== m.id);
+	}
+
+	async function runSearch() {
+		if (!searchQuery) {
+			return;
+		}
+		isSearching = true;
+		searchResults = [];
+		try {
+			const resp = await req.get<{ results: Media[] }>(
+				`/search?query=${encodeURIComponent(searchQuery)}`,
+			);
+			// People can't be mapped to, so don't offer them.
+			searchResults = (resp?.results ?? []).filter((r) => r.type !== "person");
+		} catch (err) {
+			console.error("mappings: search failed", err);
+			notify({ type: "error", text: "Search failed" });
+		}
+		isSearching = false;
+	}
+
+	async function pick(m: ImportMapping, media: Media) {
+		busyIds = [...busyIds, m.id];
+		try {
+			const updated = await req.put<ImportMapping>(`/import/mappings/${m.id}`, {
+				tmdbId: media.ids.tmdb ?? 0,
+				igdbId: media.ids.igdb ?? 0,
+			});
+			mappings = mappings.map((x) => (x.id === m.id ? updated : x));
+			notify({ type: "success", text: `Updated the match for ${m.name}` });
+			changing = undefined;
+		} catch (err) {
+			console.error("mappings: failed to update", err);
+			notify({ type: "error", text: `Couldn't update the match for ${m.name}` });
+		}
+		busyIds = busyIds.filter((id) => id !== m.id);
+	}
+
+	function startChanging(m: ImportMapping) {
+		changing = m;
+		searchQuery = m.name;
+		searchResults = [];
+		runSearch();
+	}
+</script>
+
+<svelte:head>
+	<title>Saved Import Matches</title>
+</svelte:head>
+
+<div class="content">
+	<div class="inner">
+		<h2>Saved Import Matches</h2>
+		<span class="desc">
+			When an import can't work out which content a name refers to, it asks you
+			to pick. Your choice is saved here so re-importing the same file doesn't
+			ask again. Forget a match to be asked about it next time.
+		</span>
+
+		{#if isLoading}
+			<Spinner />
+		{:else if loadError}
+			<h3>{loadError}</h3>
+		{:else if mappings.length <= 0}
+			<h3 class="empty">No saved matches yet.</h3>
+			<span class="desc">
+				They're created as you resolve prompts during an import.
+			</span>
+		{:else}
+			<div class="table-wrap">
+				<table>
+					<thead>
+						<tr>
+							<th>Name in import file</th>
+							<th>Type</th>
+							<th>Matched to</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each mappings as m (m.id)}
+							<tr>
+								<td class="name">{m.name}</td>
+								<td>{m.type}</td>
+								<td>
+									{#if contentLink(m)}
+										<a href={contentLink(m)}>
+											{m.tmdbId ? `tmdb ${m.tmdbId}` : `igdb ${m.igdbId}`}
+										</a>
+									{:else}
+										<span class="unknown">nothing</span>
+									{/if}
+								</td>
+								<td class="row-btns">
+									{#if busyIds.includes(m.id)}
+										<SpinnerTiny />
+									{:else}
+										<button onclick={() => startChanging(m)}>Change</button>
+										<button onclick={() => forget(m)}>Forget</button>
+									{/if}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+
+		<div class="btns">
+			<button onclick={() => goto(resolve("/import"))}>
+				<Icon i="arrow" />Back
+			</button>
+		</div>
+	</div>
+</div>
+
+{#if changing}
+	<Modal
+		title="Change Match"
+		desc="Pick what {changing.name} should import as"
+		onClose={() => (changing = undefined)}
+	>
+		<div class="search-row">
+			<input
+				class="plain"
+				placeholder="Search"
+				bind:value={searchQuery}
+				onkeydown={(e) => {
+					if (e.key === "Enter") {
+						runSearch();
+					}
+				}}
+			/>
+			<button onclick={() => runSearch()}>Search</button>
+		</div>
+		{#if isSearching}
+			<Spinner />
+		{:else if searchResults.length <= 0}
+			<h4 class="norm">No results</h4>
+		{:else}
+			<PosterList type="vertical">
+				{#each searchResults as r (r.ids)}
+					<Poster
+						media={r}
+						small={true}
+						disableInteraction={true}
+						hideButtons={true}
+						onClick={() => (changing ? pick(changing, r) : undefined)}
+					/>
+				{/each}
+			</PosterList>
+		{/if}
+	</Modal>
+{/if}
+
+<style lang="scss">
+	.content {
+		display: flex;
+		justify-content: center;
+		margin: 0 30px;
+	}
+
+	.inner {
+		display: flex;
+		flex-flow: column;
+		max-width: 900px;
+		width: 100%;
+
+		h2 {
+			margin-top: 20px;
+		}
+
+		.desc {
+			margin-bottom: 15px;
+			font-size: 14px;
+			opacity: 0.7;
+		}
+
+		.empty {
+			margin-top: 20px;
+		}
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+
+		th {
+			text-align: left;
+			font-size: 14px;
+			opacity: 0.7;
+			padding-bottom: 5px;
+		}
+
+		td {
+			padding: 6px 8px 6px 0;
+			vertical-align: middle;
+		}
+
+		.name {
+			font-weight: bold;
+			word-break: break-word;
+		}
+
+		.unknown {
+			opacity: 0.6;
+		}
+	}
+
+	.row-btns {
+		display: flex;
+		gap: 5px;
+		justify-content: flex-end;
+
+		button {
+			width: max-content;
+		}
+	}
+
+	.search-row {
+		display: flex;
+		gap: 5px;
+		margin-bottom: 10px;
+
+		button {
+			width: max-content;
+		}
+	}
+
+	.btns {
+		display: flex;
+		flex-flow: row;
+		margin: 20px 0;
+		gap: 5px;
+
+		button {
+			width: max-content;
+			gap: 3px;
+		}
+	}
+</style>

--- a/src/routes/(app)/import/mappings/+page.svelte
+++ b/src/routes/(app)/import/mappings/+page.svelte
@@ -43,16 +43,6 @@
 
 	load();
 
-	function contentLink(m: ImportMapping): string | undefined {
-		if (m.tmdbId) {
-			return m.type === "movie" ? `/movie/${m.tmdbId}` : `/tv/${m.tmdbId}`;
-		}
-		if (m.igdbId) {
-			return `/game/${m.igdbId}`;
-		}
-		return undefined;
-	}
-
 	async function forget(m: ImportMapping) {
 		busyIds = [...busyIds, m.id];
 		try {
@@ -139,6 +129,18 @@
 	}
 </script>
 
+{#snippet matchLink(m: ImportMapping)}
+	{#if m.tmdbId && m.type === "movie"}
+		<a href={resolve("/movie/{m.tmdbId}")}>tmdb {m.tmdbId}</a>
+	{:else if m.tmdbId}
+		<a href={resolve("/tv/{m.tmdbId}")}>tmdb {m.tmdbId}</a>
+	{:else if m.igdbId}
+		<a href={resolve("/game/{m.igdbId}")}>igdb {m.igdbId}</a>
+	{:else}
+		<span class="unknown">nothing</span>
+	{/if}
+{/snippet}
+
 <svelte:head>
 	<title>Saved Import Matches</title>
 </svelte:head>
@@ -178,13 +180,7 @@
 								<td class="name">{m.name}</td>
 								<td>{m.type}</td>
 								<td>
-									{#if contentLink(m)}
-										<a href={contentLink(m)}>
-											{m.tmdbId ? `tmdb ${m.tmdbId}` : `igdb ${m.igdbId}`}
-										</a>
-									{:else}
-										<span class="unknown">nothing</span>
-									{/if}
+									{@render matchLink(m)}
 								</td>
 								<td class="row-btns">
 									{#if busyIds.includes(m.id)}
@@ -228,6 +224,11 @@
 			/>
 			<button onclick={() => runSearch()}>Search</button>
 		</div>
+		<span class="current-match">
+			Currently matched to {@render matchLink(changing)}. This does not affect
+			your saved list, you must manually add or remove entries to modify your
+			saved list.
+		</span>
 		{#if isSearching}
 			<Spinner />
 		{:else if searchResults.length <= 0}
@@ -314,6 +315,13 @@
 		button {
 			width: max-content;
 		}
+	}
+
+	.current-match {
+		display: block;
+		font-size: 14px;
+		opacity: 0.7;
+		margin-bottom: 10px;
 	}
 
 	.search-row {

--- a/src/routes/(app)/import/mappings/+page.svelte
+++ b/src/routes/(app)/import/mappings/+page.svelte
@@ -107,6 +107,10 @@
 			const updated = await req.put<ImportMapping>(`/import/mappings/${m.id}`, {
 				tmdbId: media.ids.tmdb ?? 0,
 				igdbId: media.ids.igdb ?? 0,
+				// Only used by the server when the mapping has no type of its
+				// own, which happens for ignored names the import file gave
+				// no type to.
+				type: getContentTypeFromMedia(media),
 			});
 			mappings = mappings.map((x) => (x.id === m.id ? updated : x));
 			notify({ type: "success", text: `Updated the match for ${m.name}` });
@@ -144,6 +148,18 @@
 		isDeletingAll = false;
 	}
 
+	// Matches first, ignored names after them, each set alphabetical. Sorted
+	// here rather than by the server so a row moves as soon as it changes,
+	// without reloading the list.
+	const sortedMappings = $derived(
+		[...mappings].sort((a, b) => {
+			if (a.ignored !== b.ignored) {
+				return a.ignored ? 1 : -1;
+			}
+			return a.name.localeCompare(b.name);
+		}),
+	);
+
 	function startChanging(m: ImportMapping) {
 		changing = m;
 		searchQuery = m.name;
@@ -153,7 +169,9 @@
 </script>
 
 {#snippet matchLink(m: ImportMapping)}
-	{#if m.tmdbId && m.type === "movie"}
+	{#if m.ignored}
+		<span class="ignored">ignored</span>
+	{:else if m.tmdbId && m.type === "movie"}
 		<a href={resolve("/movie/{m.tmdbId}")}>tmdb {m.tmdbId}</a>
 	{:else if m.tmdbId}
 		<a href={resolve("/tv/{m.tmdbId}")}>tmdb {m.tmdbId}</a>
@@ -174,7 +192,9 @@
 		<span class="desc">
 			When an import can't work out which content a name refers to, it asks you
 			to pick. Your choice is saved here so re-importing the same file doesn't
-			ask again. Forget a match to be asked about it next time.
+			ask again, including names you chose to ignore. Change an ignored name to
+			start importing it again, or forget a match to be asked about it next
+			time.
 		</span>
 
 		{#if isLoading}
@@ -198,10 +218,10 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each mappings as m (m.id)}
+						{#each sortedMappings as m (m.id)}
 							<tr>
 								<td class="name">{m.name}</td>
-								<td>{m.type}</td>
+								<td>{m.type ? m.type : "any"}</td>
 								<td>
 									{@render matchLink(m)}
 								</td>
@@ -276,9 +296,10 @@
 			<button onclick={() => runSearch()}>Search</button>
 		</div>
 		<span class="current-match">
-			Currently matched to {@render matchLink(changing)}. This does not affect
-			your saved list, you must manually add or remove entries to modify your
-			saved list.
+			Currently {changing.ignored ? "" : "matched to "}{@render matchLink(
+				changing,
+			)}. This does not affect your saved list, you must manually add or remove
+			entries to modify your saved list.
 		</span>
 		{#if isSearching}
 			<Spinner />
@@ -353,7 +374,8 @@
 			word-break: break-word;
 		}
 
-		.unknown {
+		.unknown,
+		.ignored {
 			opacity: 0.6;
 		}
 	}

--- a/src/routes/(app)/import/mappings/+page.svelte
+++ b/src/routes/(app)/import/mappings/+page.svelte
@@ -121,6 +121,29 @@
 		busyIds = busyIds.filter((id) => id !== m.id);
 	}
 
+	// Set while the delete all confirmation modal is open.
+	let confirmingDeleteAll = $state(false);
+	let isDeletingAll = $state(false);
+
+	async function deleteAll() {
+		isDeletingAll = true;
+		const nid = notify({ text: "Deleting saved matches", type: "loading" });
+		try {
+			await req.delete("/import/mappings");
+			mappings = [];
+			notify({ id: nid, text: "All saved matches deleted!", type: "success" });
+			confirmingDeleteAll = false;
+		} catch (err) {
+			console.error("mappings: failed to delete all", err);
+			notify({
+				id: nid,
+				text: "Couldn't delete your saved matches",
+				type: "error",
+			});
+		}
+		isDeletingAll = false;
+	}
+
 	function startChanging(m: ImportMapping) {
 		changing = m;
 		searchQuery = m.name;
@@ -201,9 +224,37 @@
 			<button onclick={() => goto(resolve("/import"))}>
 				<Icon i="arrow" />Back
 			</button>
+			{#if mappings.length > 0}
+				<button onclick={() => (confirmingDeleteAll = true)}>
+					Delete All Matches
+				</button>
+			{/if}
 		</div>
 	</div>
 </div>
+
+{#if confirmingDeleteAll}
+	<Modal
+		title="Delete All Saved Matches"
+		desc="Are you sure you want to forget all {mappings.length} of your saved matches?"
+		maxWidth="500px"
+		onClose={() => (confirmingDeleteAll = false)}
+	>
+		<div class="confirm-inner">
+			<span class="desc">
+				Your watched list isn't touched, only the remembered choices. You'll be
+				asked to pick again for these names on your next import.
+			</span>
+			<button
+				class="delete-all-btn"
+				onclick={() => deleteAll()}
+				disabled={isDeletingAll}
+			>
+				Yes, delete all saved matches
+			</button>
+		</div>
+	</Modal>
+{/if}
 
 {#if changing}
 	<Modal
@@ -314,6 +365,28 @@
 
 		button {
 			width: max-content;
+		}
+	}
+
+	.confirm-inner {
+		display: flex;
+		flex-flow: column;
+		gap: 10px;
+
+		// The pages .desc styling is scoped to the table view, so the same
+		// look is repeated here for the text inside the modal.
+		.desc {
+			font-size: 14px;
+			opacity: 0.7;
+		}
+	}
+
+	.delete-all-btn {
+		width: max-content;
+		margin-left: auto;
+
+		&:hover {
+			color: $error;
 		}
 	}
 

--- a/src/routes/(app)/import/mappings/+page.svelte
+++ b/src/routes/(app)/import/mappings/+page.svelte
@@ -56,7 +56,10 @@
 			notify({ type: "success", text: `Forgot the match for ${m.name}` });
 		} catch (err) {
 			console.error("mappings: failed to forget", err);
-			notify({ type: "error", text: `Couldn't forget the match for ${m.name}` });
+			notify({
+				type: "error",
+				text: `Couldn't forget the match for ${m.name}`,
+			});
 		}
 		busyIds = busyIds.filter((id) => id !== m.id);
 	}
@@ -92,7 +95,10 @@
 			changing = undefined;
 		} catch (err) {
 			console.error("mappings: failed to update", err);
-			notify({ type: "error", text: `Couldn't update the match for ${m.name}` });
+			notify({
+				type: "error",
+				text: `Couldn't update the match for ${m.name}`,
+			});
 		}
 		busyIds = busyIds.filter((id) => id !== m.id);
 	}

--- a/src/routes/(app)/import/mappings/+page.svelte
+++ b/src/routes/(app)/import/mappings/+page.svelte
@@ -9,7 +9,12 @@
 	import SpinnerTiny from "@/lib/SpinnerTiny.svelte";
 	import { req } from "@/lib/util/api";
 	import { notify } from "@/lib/util/notify";
-	import type { Media, ImportMapping } from "@/types";
+	import {
+		getContentTypeFromMedia,
+		type ContentType,
+		type Media,
+		type ImportMapping,
+	} from "@/types";
 
 	let mappings: ImportMapping[] = $state([]);
 	let isLoading = $state(true);
@@ -64,6 +69,18 @@
 		busyIds = busyIds.filter((id) => id !== m.id);
 	}
 
+	// Import content types line up with content types, apart from episodes,
+	// which are searched for as their show.
+	function mappingContentType(t: string): ContentType | undefined {
+		if (t === "tv_episode") {
+			return "tv";
+		}
+		if (t === "movie" || t === "tv" || t === "game") {
+			return t;
+		}
+		return undefined;
+	}
+
 	async function runSearch() {
 		if (!searchQuery) {
 			return;
@@ -74,8 +91,19 @@
 			const resp = await req.get<{ results: Media[] }>(
 				`/search?query=${encodeURIComponent(searchQuery)}`,
 			);
-			// People can't be mapped to, so don't offer them.
-			searchResults = (resp?.results ?? []).filter((r) => r.type !== "person");
+			// A mapping keeps the content type it was saved with, so only
+			// offer results of that same type. Picking a different type would
+			// leave the row keyed as one type while holding another types id,
+			// and lookups are done on the type, so it would never match.
+			const wanted = changing ? mappingContentType(changing.type) : undefined;
+			searchResults = (resp?.results ?? []).filter((r) => {
+				const t = getContentTypeFromMedia(r);
+				// People, and anything we can't type, can't be mapped to.
+				if (!t) {
+					return false;
+				}
+				return !wanted || t === wanted;
+			});
 		} catch (err) {
 			console.error("mappings: search failed", err);
 			notify({ type: "error", text: "Search failed" });

--- a/src/routes/(app)/import/process/+page.svelte
+++ b/src/routes/(app)/import/process/+page.svelte
@@ -6,6 +6,7 @@
 
 <script lang="ts">
 	import { goto } from "$app/navigation";
+	import Checkbox from "@/lib/Checkbox.svelte";
 	import DropDown from "@/lib/DropDown.svelte";
 	import Error from "@/lib/Error.svelte";
 	import Icon from "@/lib/Icon.svelte";
@@ -38,6 +39,10 @@
 	}
 
 	let rList: ImportedList[] = $state([]);
+	// When on, previously saved matches are ignored, so every ambiguous name
+	// is asked about again. Deliberately not remembered between imports, it
+	// is a choice for this run rather than a preference.
+	let ignoreSavedMatches = $state(false);
 	let isImporting = $state(false);
 	let importText = $state("");
 	let cancelled = $state(false);
@@ -539,7 +544,10 @@
 			rList = rList;
 			return;
 		}
-		const resp = await req.post<ImportResponse>("/import", item);
+		const resp = await req.post<ImportResponse>("/import", {
+			...item,
+			ignoreSavedMatches,
+		});
 		return new Promise((res, rej) => {
 			if (resp.type === ImportResponseType.IMPORT_MULTI) {
 				console.log("Import found multiple responses for content", resp);
@@ -788,6 +796,17 @@
 						</tbody>
 					</table>
 				</div>
+				<div class="import-opts">
+					<Checkbox
+						name="Ask about every match again"
+						bind:value={ignoreSavedMatches}
+						disabled={isImporting}
+					/>
+					<span class="opt-desc">
+						Ignores matches saved from previous imports, so you can pick
+						again for names that were matched incorrectly.
+					</span>
+				</div>
 				<div class="btns">
 					<button onclick={() => goto(resolve("/import"))}>
 						<Icon i="arrow" />Back
@@ -944,6 +963,20 @@
 					padding-left: 3px;
 				}
 			}
+		}
+	}
+
+	.import-opts {
+		display: flex;
+		flex-flow: row;
+		align-items: center;
+		flex-wrap: wrap;
+		margin-top: 20px;
+		gap: 8px;
+
+		.opt-desc {
+			font-size: 14px;
+			opacity: 0.7;
 		}
 	}
 

--- a/src/routes/(app)/import/process/+page.svelte
+++ b/src/routes/(app)/import/process/+page.svelte
@@ -803,7 +803,7 @@
 						disabled={isImporting}
 					/>
 					<span class="opt-desc">
-						Ignores matches saved from previous imports, so you can pick again
+						Ignore matches saved from previous imports, so you can pick again
 						for names that were matched incorrectly.
 					</span>
 				</div>

--- a/src/routes/(app)/import/process/+page.svelte
+++ b/src/routes/(app)/import/process/+page.svelte
@@ -930,7 +930,7 @@
 						importMultiItem = undefined;
 					}}
 				>
-					None of these, stop asking about it
+					None of these
 				</button>
 			</div>
 		</Modal>

--- a/src/routes/(app)/import/process/+page.svelte
+++ b/src/routes/(app)/import/process/+page.svelte
@@ -529,16 +529,29 @@
 			store.parsedImportedList = rList;
 			goto(resolve("/import/some-failed"));
 		} else {
+			const ignoredCount = rList.filter(
+				(i) => i.state === ImportResponseType.IMPORT_IGNORED,
+			).length;
 			notify({
 				type: "success",
-				text: "All content successfully imported!",
+				text:
+					ignoredCount > 0
+						? `All content imported, apart from ${ignoredCount} you chose to ignore.`
+						: "All content successfully imported!",
 				time: 15000,
 			});
 			goto(resolve("/"));
 		}
 	}
 
-	async function doImport(item: ImportedList) {
+	/**
+	 * Import one item.
+	 *
+	 * `ignoreThisItem` gives up on matching it instead, which imports nothing
+	 * and saves that decision, so this name isn't asked about again on any
+	 * future import.
+	 */
+	async function doImport(item: ImportedList, ignoreThisItem = false) {
 		if (!item.name?.trim()) {
 			item.state = ImportResponseType.IMPORT_NOTFOUND;
 			rList = rList;
@@ -547,6 +560,7 @@
 		const resp = await req.post<ImportResponse>("/import", {
 			...item,
 			ignoreSavedMatches,
+			ignoreThisItem,
 		});
 		return new Promise((res, rej) => {
 			if (resp.type === ImportResponseType.IMPORT_MULTI) {
@@ -699,6 +713,8 @@
 													<Icon i="close" wh={22} />
 												{:else if l.state === ImportResponseType.IMPORT_EXISTS}
 													<Icon i="check" wh={22} />
+												{:else if l.state === ImportResponseType.IMPORT_IGNORED}
+													<Icon i="eye-closed" wh={22} />
 												{/if}
 											</div>
 										</td>
@@ -896,6 +912,27 @@
 					/>
 				{/each}
 			</PosterList>
+			<div class="ignore-row">
+				<button
+					onclick={async () => {
+						const item = rList.find(
+							(i) => i.name === importMultiItem?.original.name,
+						);
+						if (!item) {
+							return;
+						}
+						try {
+							await doImport(item, true);
+							importMultiItem?.callback(undefined);
+						} catch (err) {
+							importMultiItem?.callback(String(err));
+						}
+						importMultiItem = undefined;
+					}}
+				>
+					None of these, stop asking about it
+				</button>
+			</div>
 		</Modal>
 	{/if}
 {:catch err}
@@ -903,6 +940,18 @@
 {/await}
 
 <style lang="scss">
+	// The give up button sits on its own row under the results, centered so
+	// it doesn't read as one of the choices above it.
+	.ignore-row {
+		display: flex;
+		justify-content: center;
+		margin-top: 15px;
+
+		button {
+			width: max-content;
+		}
+	}
+
 	.content {
 		display: flex;
 		width: 100%;

--- a/src/routes/(app)/import/process/+page.svelte
+++ b/src/routes/(app)/import/process/+page.svelte
@@ -803,8 +803,8 @@
 						disabled={isImporting}
 					/>
 					<span class="opt-desc">
-						Ignores matches saved from previous imports, so you can pick
-						again for names that were matched incorrectly.
+						Ignores matches saved from previous imports, so you can pick again
+						for names that were matched incorrectly.
 					</span>
 				</div>
 				<div class="btns">

--- a/src/routes/(app)/import/some-failed/+page.svelte
+++ b/src/routes/(app)/import/some-failed/+page.svelte
@@ -13,12 +13,43 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
 	import { resolve } from "$app/paths";
+	import Icon from "@/lib/Icon.svelte";
+	import SpinnerTiny from "@/lib/SpinnerTiny.svelte";
+	import { req } from "@/lib/util/api";
+	import { notify } from "@/lib/util/notify";
 	import { store } from "@/store.svelte";
 	import { ImportResponseType, type ImportedList } from "@/types";
 	import { onMount } from "svelte";
 
 	let failed: ImportedList[] = $state([]);
 	let successCount = $state(0);
+	let ignoredCount = $state(0);
+	// Names with an ignore request in flight, so only that rows button is
+	// disabled rather than the whole list.
+	let ignoring: string[] = $state([]);
+
+	/**
+	 * Give up on an entry for good. Nothing is imported, the decision is
+	 * saved as an ignored match, and future imports skip the name instead of
+	 * failing on it again.
+	 */
+	async function ignore(item: ImportedList) {
+		const name = item.name;
+		if (!name) {
+			return;
+		}
+		ignoring = [...ignoring, name];
+		try {
+			await req.post("/import", { ...item, ignoreThisItem: true });
+			failed = failed.filter((f) => f !== item);
+			ignoredCount++;
+			notify({ type: "success", text: `Ignoring ${name} from now on` });
+		} catch (err) {
+			console.error("some-failed: failed to ignore", err);
+			notify({ type: "error", text: `Couldn't ignore ${name}` });
+		}
+		ignoring = ignoring.filter((n) => n !== name);
+	}
 
 	onMount(() => {
 		if (store.parsedImportedList) {
@@ -31,6 +62,8 @@
 				) {
 					failed.push(item);
 					failed = failed;
+				} else if (item.state === ImportResponseType.IMPORT_IGNORED) {
+					ignoredCount++;
 				} else {
 					successCount++;
 				}
@@ -48,7 +81,11 @@
 		<h5 class="norm">
 			You can search for the failed imports and manually add them.
 		</h5>
-		<h4 class="norm">{successCount} succeeded and {failed.length} failed.</h4>
+		<h4 class="norm">
+			{successCount} succeeded and {failed.length} failed{ignoredCount > 0
+				? `, ${ignoredCount} ignored`
+				: ""}.
+		</h4>
 
 		{#if failed}
 			<ul>
@@ -57,6 +94,18 @@
 				{#each failed as l}
 					<li>
 						<span>{l.name}</span>
+						<div class="ignore-wrap">
+							{#if ignoring.includes(l.name ?? "")}
+								<SpinnerTiny />
+							{:else}
+								<button
+									title="Never try to import this name again"
+									onclick={() => ignore(l)}
+								>
+									<Icon i="eye-closed" wh={18} />Ignore
+								</button>
+							{/if}
+						</div>
 					</li>
 				{/each}
 			</ul>
@@ -109,6 +158,17 @@
 				margin-left: auto;
 
 				button {
+					width: max-content;
+				}
+			}
+
+			.ignore-wrap {
+				margin-left: auto;
+
+				button {
+					display: flex;
+					align-items: center;
+					gap: 3px;
 					width: max-content;
 				}
 			}

--- a/src/types.ts
+++ b/src/types.ts
@@ -550,6 +550,7 @@ export interface ImportMapping {
 	type: string;
 	tmdbId: number;
 	igdbId: number;
+	ignored: boolean;
 }
 
 export enum ImportResponseType {
@@ -558,6 +559,7 @@ export enum ImportResponseType {
 	IMPORT_MULTI = "IMPORT_MULTI",
 	IMPORT_NOTFOUND = "IMPORT_NOTFOUND",
 	IMPORT_EXISTS = "IMPORT_EXISTS",
+	IMPORT_IGNORED = "IMPORT_IGNORED",
 }
 
 export interface ImportResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -544,6 +544,14 @@ export interface TMDBRegions {
 	}[];
 }
 
+export interface ImportMapping {
+	id: number;
+	name: string;
+	type: string;
+	tmdbId: number;
+	igdbId: number;
+}
+
 export enum ImportResponseType {
 	IMPORT_SUCCESS = "IMPORT_SUCCESS",
 	IMPORT_FAILED = "IMPORT_FAILED",


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run format` or using prettier manually. -->

AI Disclosure: Yes, I used Claude code. Yes, I understand the code, I've used Go before, and I used Svelte/SvelteKit at my previous job (although admittedly that was a few years ago).

### Changes made

I've added a new database table import_mappings (the table is created by the existing automigrate) for storing import mappings so that they can be re-used on the import page (by default the mappings are used, there is a checkbox on the import process page that asks about every match again). The mappings are saved per-user so each user can pick their own mappings. 

There are new endpoints: `GET /import/mappings`, `PUT /import/mappings/:id`, `DELETE /import/mappings/:id`, `DELETE /import/mappings/`. They are scoped by user ID so users cannot change other users' mappings and the user IDs do not come from the URL so they cannot be tampered with.

I've added a new page for viewing, modifying, and removing saved import matches. You can access the page by clicking the button on the bottom of the import page. Changing the saved import matches does not update the users list, they are responsible for updating their own list manually. You can also delete all matches with a button.

I've also added the ability to "ignore" matches that simply don't exist when none of the suggested TMDB replacements are suitable.

Just like my previous PR, I've also added tests, you can run the new tests (plus existing tests) with `cd server && go test ./...`

I deployed a Docker container from my fork containing these changes, you can similarly test it if you'd like, it's found at `ghcr.io/ipkpjersi/watcharr:deploy-save-import-mappings`
 
This has been tested as working, it works quite well for me.  This PR goes quite well with my other one.
 
This one is may be worth some manual testing by a maintainer to make sure it's something you'd want, I'm hoping it is.
 
A benefit of this feature is after watching a show on Plex and having it import from Plex automatically via a cronjob I created, when I import my MAL list to import the rating of the show, I no longer have to pick all of the ambiguous matches every single time for my entire MAL list. This ends up saving me a bunch of time. Since this feature also has the ability to "ignore" matches that simply don't exist when none of the suggested replacements are suitable, that also saves considerable time when re-importing a file that increases in size over time like MAL backups do.

With my two PRs combined, Watcharr becomes much more usable to me, and hopefully more usable to others too.