### PR TITLE
Prevent zooming while searching on an iPhone

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -552,6 +552,7 @@
 
 		input {
 			width: 100%;
+			font-size: 16px;
 			font-weight: bold;
 			text-align: center;
 			box-shadow: 4px 4px 0px 0px $text-color;


### PR DESCRIPTION
The iPhone zooms into an input field when the font size is less than 16px.
In my opinion, that doesn't look very good.

### Changes made

Set the font-size to 16px for the input field.
