### PR TITLE
(fix) Prevent the iPhone from zooming into input fields

### DIFF
--- a/src/styles/norm.scss
+++ b/src/styles/norm.scss
@@ -104,6 +104,13 @@
 		border-radius: 5px;
 		width: 100%;
 	}
+
+	@media (max-width: 768px) and (pointer: coarse) {
+		input,
+		textarea {
+			font-size: 16px;
+		}
+	}
 }
 
 :global {


### PR DESCRIPTION
The iPhone zooms into an input field when the font size is less than 16px.
In my opinion, that doesn't look very good.
To fix this, you can either increase the font-size for mobile devices to 16px or add "maximum-scale=1" to the meta viewport tag.
For accessibility reasons, I opted for the former. This is especially because the text in input fields on mobile devices was very small before the change.

### Changes made
Set the font-size globally to 16px for small touch-enabled devices
