### PR TITLE
fix: connection to Jellyfin 12 (Authorization header)

### DIFF
--- a/server/feature/auth/auth.go
+++ b/server/feature/auth/auth.go
@@ -205,7 +205,10 @@ func (s *Service) LoginJellyfin(userL *entity.User) (AuthResponse, error) {
 		return AuthResponse{}, errors.New("request failed")
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-Emby-Authorization", "MediaBrowser Client=\"Watcharr\", Device=\"HTTP\", DeviceId=\"WatcharrFor"+userL.Username+"\", Version=\"10.8.0\"")
+	// Jellyfin 12 requires Authorization, the legacy X-Emby-Authorization is kept for older versions
+	authHeader := "MediaBrowser Client=\"Watcharr\", Device=\"HTTP\", DeviceId=\"WatcharrFor" + userL.Username + "\", Version=\"10.8.0\""
+	req.Header.Add("Authorization", authHeader)
+	req.Header.Add("X-Emby-Authorization", authHeader)
 	res, err := client.Do(req)
 	if err != nil {
 		slog.Error("making request to jellyfin for auth failed", "error", err)

--- a/server/feature/jellyfin/jellyfin.go
+++ b/server/feature/jellyfin/jellyfin.go
@@ -120,6 +120,8 @@ func (s *Service) JellyfinAPIRequest(method string, ep string, p map[string]stri
 	if userToken != "" {
 		authHeader += ", Token=\"" + userToken + "\""
 	}
+	// Jellyfin 12 requires Authorization, the legacy X-Emby-Authorization is kept for older versions
+	req.Header.Add("Authorization", authHeader)
 	req.Header.Add("X-Emby-Authorization", authHeader)
 	res, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Jellyfin 12 disabled legacy authorization by default, so it no longer reads the X-Emby-Authorization header.
Send the auth header via both, the standard Authorization header (MediaBrowser scheme, required by Jellyfin 12+) and the legacy X-Emby-Authorization header (still used by older Jellyfin and Emby versions), so all server versions keep working.
Fixes #1117 

### Changes made
- auth: LoginJellyfin now sends Authorization alongside X-Emby-Authorization.
- jellyfin: JellyfinAPIRequest now sends Authorization alongside X-Emby-Authorization.