### PR TITLE
fix jellyfin 12 Authorization header name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 These changes are awaiting release:
 
+## Fixed
+
+- Jellyfin 12 Authentication (`X-Emby-Authorization` -> `Authorization`).
+  - **IMPORTANT** Jellyfin servers older than 10.11 may no longer work, but 10.11+ will function. For support, your Jellyfin server should be on 10.11+.
+
 # [4.2.1] - 2026-08-04T00:40:00Z
 
 ## Fixed

--- a/server/feature/auth/auth.go
+++ b/server/feature/auth/auth.go
@@ -205,7 +205,7 @@ func (s *Service) LoginJellyfin(userL *entity.User) (AuthResponse, error) {
 		return AuthResponse{}, errors.New("request failed")
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-Emby-Authorization", "MediaBrowser Client=\"Watcharr\", Device=\"HTTP\", DeviceId=\"WatcharrFor"+userL.Username+"\", Version=\"10.8.0\"")
+	req.Header.Add("Authorization", "MediaBrowser Client=\"Watcharr\", Device=\"HTTP\", DeviceId=\"WatcharrFor"+userL.Username+"\", Version=\"10.8.0\"")
 	res, err := client.Do(req)
 	if err != nil {
 		slog.Error("making request to jellyfin for auth failed", "error", err)

--- a/server/feature/jellyfin/jellyfin.go
+++ b/server/feature/jellyfin/jellyfin.go
@@ -120,7 +120,7 @@ func (s *Service) JellyfinAPIRequest(method string, ep string, p map[string]stri
 	if userToken != "" {
 		authHeader += ", Token=\"" + userToken + "\""
 	}
-	req.Header.Add("X-Emby-Authorization", authHeader)
+	req.Header.Add("Authorization", authHeader)
 	res, err := client.Do(req)
 	if err != nil {
 		slog.Error("making request to jellyfin for auth failed", "error", err)


### PR DESCRIPTION
Jellyfin 12 now disables legacy auth by default, which I couldn't find docs on, but for us seems to be a simple change of the Authorization header name from `X-Emby-Authorization` to `Authorization`.

Jellyfin 10.11 continues to work since it already supports the new Authorization header name.

Also tested Emby, which seems to accept the Authorization header name (without the X-Emby- prefix) too (not documented I don't think, but I guess they allow both for resilience purposes, which is nice so we can rely on that).

Closes #1117
